### PR TITLE
Add circe implicits

### DIFF
--- a/core/src/main/scala/eu/shiftforward/apso/json/Implicits.scala
+++ b/core/src/main/scala/eu/shiftforward/apso/json/Implicits.scala
@@ -96,11 +96,15 @@ object Implicits {
      * @return flattened key set
      */
     def flattenedKeySet(separator: String = ".", ignoreNull: Boolean = true): Set[String] = {
-      val fields = json.as[JsonObject].toOption.get.toMap.toSet
-      fields.flatMap {
-        case (k, v) if v.isObject => v.flattenedKeySet(separator, ignoreNull).map(k + separator + _)
-        case (_, v) if v.isNull && ignoreNull => Set.empty[String]
-        case (k, _) => Set(k)
+      json.asObject match {
+        case None => Set.empty
+        case Some(jo) =>
+          val fields = jo.toMap.toSet
+          fields.flatMap {
+            case (k, v) if v.isObject => v.flattenedKeySet(separator, ignoreNull).map(k + separator + _)
+            case (_, v) if v.isNull && ignoreNull => Set.empty[String]
+            case (k, _) => Set(k)
+          }
       }
     }
 

--- a/core/src/main/scala/eu/shiftforward/apso/json/Implicits.scala
+++ b/core/src/main/scala/eu/shiftforward/apso/json/Implicits.scala
@@ -128,12 +128,15 @@ object Implicits {
      *
      * @param fieldPath path from the root of the json object to the field
      * @param separator character that separates each element of the path
-     * @return an option with the json without the deleted value
+     * @return the json without the deleted value
      */
-    def deleteField(fieldPath: String, separator: Char = '.'): Option[Json] =
-      getCursor(fieldPath, separator).delete.top
+    def deleteField(fieldPath: String, separator: Char = '.'): Json = {
+      require(fieldPath.nonEmpty, "The field path must have value.")
 
-    private[this] def getCursor(fieldPath: String, separator: Char): ACursor =
+      getCursor(fieldPath, separator).delete.top.get
+    }
+
+    def getCursor(fieldPath: String, separator: Char): ACursor =
       fieldPath.split(separator)
         .foldLeft(json.hcursor: ACursor) {
           case (cursor, field) =>

--- a/core/src/main/scala/eu/shiftforward/apso/json/Implicits.scala
+++ b/core/src/main/scala/eu/shiftforward/apso/json/Implicits.scala
@@ -119,7 +119,7 @@ object Implicits {
      * @return an option with the field value
      */
     def getField[A: Decoder](fieldPath: String, separator: Char = '.'): Option[A] =
-      getCursor(fieldPath, separator).as[A].toOption
+      getCursor(fieldPath, separator).as[A].fold(_ => None, Some(_))
 
     /**
      * Delete a field on a json object.
@@ -136,6 +136,13 @@ object Implicits {
       getCursor(fieldPath, separator).delete.top.get
     }
 
+    /**
+      * Returns a cursor on the field on the end of the tree, separated by the separator character.
+      *
+      * @param fieldPath path from the root of the json object to the field
+      * @param separator character that separates each element of the path
+      * @return cursor to the field value
+      */
     def getCursor(fieldPath: String, separator: Char): ACursor =
       fieldPath.split(separator)
         .foldLeft(json.hcursor: ACursor) {

--- a/core/src/main/scala/eu/shiftforward/apso/json/Implicits.scala
+++ b/core/src/main/scala/eu/shiftforward/apso/json/Implicits.scala
@@ -137,12 +137,12 @@ object Implicits {
     }
 
     /**
-      * Returns a cursor on the field on the end of the tree, separated by the separator character.
-      *
-      * @param fieldPath path from the root of the json object to the field
-      * @param separator character that separates each element of the path
-      * @return cursor to the field value
-      */
+     * Returns a cursor on the field on the end of the tree, separated by the separator character.
+     *
+     * @param fieldPath path from the root of the json object to the field
+     * @param separator character that separates each element of the path
+     * @return cursor to the field value
+     */
     def getCursor(fieldPath: String, separator: Char): ACursor =
       fieldPath.split(separator)
         .foldLeft(json.hcursor: ACursor) {

--- a/core/src/test/scala/eu/shiftforward/apso/json/ImplicitsSpec.scala
+++ b/core/src/test/scala/eu/shiftforward/apso/json/ImplicitsSpec.scala
@@ -97,7 +97,7 @@ class ImplicitsSpec extends Specification {
       val expected =
         """{ "a": {"b": {"c": 1, "d": {"e": 3}}, "f": 5}, "g": 4 }"""
 
-      res mustEqual parse(expected).right.get
+      res mustEqual parse(expected).toTry.get
     }
 
     "provide a method to create a circe json object from complete paths (with a custom separator)" in {
@@ -128,6 +128,7 @@ class ImplicitsSpec extends Specification {
       obj.flattenedKeySet(".", ignoreNull = true) === Set("a", "b.c")
       obj.flattenedKeySet(".", ignoreNull = false) === Set("a", "b.c", "d")
       obj.flattenedKeySet("/", ignoreNull = true) === Set("a", "b/c")
+      1.asJson.flattenedKeySet() === Set.empty
     }
 
     "provide a method to get a field from a JSON object" in {

--- a/core/src/test/scala/eu/shiftforward/apso/json/ImplicitsSpec.scala
+++ b/core/src/test/scala/eu/shiftforward/apso/json/ImplicitsSpec.scala
@@ -97,7 +97,7 @@ class ImplicitsSpec extends Specification {
       val expected =
         """{ "a": {"b": {"c": 1, "d": {"e": 3}}, "f": 5}, "g": 4 }"""
 
-      res mustEqual parse(expected).fold(throw _, r => r)
+      res mustEqual parse(expected).fold(throw _, identity)
     }
 
     "provide a method to create a circe json object from complete paths (with a custom separator)" in {
@@ -111,22 +111,20 @@ class ImplicitsSpec extends Specification {
       val expected =
         """{ "a": {"b": {"c": 1, "d": {"e": 3}}, "f": 5}, "g": 4 }"""
 
-      res mustEqual parse(expected).fold(throw _, r => r)
+      res mustEqual parse(expected).fold(throw _, identity)
     }
 
     "provide a method to get the key set of a JsObject" in {
-      import eu.shiftforward.apso.json.Implicits.{ ApsoJsonObject => _, _ }
-
       val obj = """{"a":1,"b":{"c":2},"d":null}""".parseJson.asJsObject
+
       obj.flattenedKeySet(".", ignoreNull = true) === Set("a", "b.c")
       obj.flattenedKeySet(".", ignoreNull = false) === Set("a", "b.c", "d")
       obj.flattenedKeySet("/", ignoreNull = true) === Set("a", "b/c")
     }
 
     "provide a method to get the key set of a JSON object" in {
-      import eu.shiftforward.apso.json.Implicits.{ ApsoJsonJsObject => _ }
+      val obj = parse("""{"a":1,"b":{"c":2},"d":null}""").fold(throw _, identity)
 
-      val obj = parse("""{"a":1,"b":{"c":2},"d":null}""").fold(throw _, r => r)
       obj.flattenedKeySet(".", ignoreNull = true) === Set("a", "b.c")
       obj.flattenedKeySet(".", ignoreNull = false) === Set("a", "b.c", "d")
       obj.flattenedKeySet("/", ignoreNull = true) === Set("a", "b/c")
@@ -134,18 +132,18 @@ class ImplicitsSpec extends Specification {
     }
 
     "provide a method to get a field from a JSON object" in {
+      val obj = parse("""{"a":"abc","b":{"c":2},"d":null}""").fold(throw _, identity)
 
-      val obj = parse("""{"a":"abc","b":{"c":2},"d":null}""").fold(throw _, r => r)
       obj.getField[Int]("b.c") must beSome(2)
       obj.getField[Int]("b,c", ',') must beSome(2)
       obj.getField[String]("a") must beSome("abc")
     }
 
     "provide a method to delete a field from a JSON object" in {
-      val obj = parse("""{"a":"abc","b":{"c":2},"d":null}""").fold(throw _, r => r)
+      val obj = parse("""{"a":"abc","b":{"c":2},"d":null}""").fold(throw _, identity)
 
-      obj.deleteField("b.c") must beEqualTo(parse("""{"a":"abc","b":{},"d":null}""").fold(throw _, r => r))
-      obj.deleteField("a") must beEqualTo(parse("""{"b":{"c":2},"d":null}""").fold(throw _, r => r))
+      obj.deleteField("b.c") must beEqualTo(parse("""{"a":"abc","b":{},"d":null}""").fold(throw _, identity))
+      obj.deleteField("a") must beEqualTo(parse("""{"b":{"c":2},"d":null}""").fold(throw _, identity))
       obj.deleteField("") must throwAn[IllegalArgumentException]
     }
   }

--- a/core/src/test/scala/eu/shiftforward/apso/json/ImplicitsSpec.scala
+++ b/core/src/test/scala/eu/shiftforward/apso/json/ImplicitsSpec.scala
@@ -6,7 +6,7 @@ import io.circe.parser._
 import spray.json.DefaultJsonProtocol._
 import spray.json._
 
-import eu.shiftforward.apso.json.Implicits.{ ApsoJsonObject => _, _ }
+import eu.shiftforward.apso.json.Implicits._
 
 class ImplicitsSpec extends Specification {
   "The Apso Json Implicits should" should {
@@ -115,6 +115,8 @@ class ImplicitsSpec extends Specification {
     }
 
     "provide a method to get the key set of a JsObject" in {
+      import eu.shiftforward.apso.json.Implicits.{ ApsoJsonObject => _, _ }
+
       val obj = """{"a":1,"b":{"c":2},"d":null}""".parseJson.asJsObject
       obj.flattenedKeySet(".", ignoreNull = true) === Set("a", "b.c")
       obj.flattenedKeySet(".", ignoreNull = false) === Set("a", "b.c", "d")
@@ -122,7 +124,7 @@ class ImplicitsSpec extends Specification {
     }
 
     "provide a method to get the key set of a JSON object" in {
-      import eu.shiftforward.apso.json.Implicits.{ ApsoJsonObject }
+      import eu.shiftforward.apso.json.Implicits.{ ApsoJsonJsObject => _ }
 
       val obj = parse("""{"a":1,"b":{"c":2},"d":null}""").right.get
       obj.flattenedKeySet(".", ignoreNull = true) === Set("a", "b.c")
@@ -132,7 +134,6 @@ class ImplicitsSpec extends Specification {
     }
 
     "provide a method to get a field from a JSON object" in {
-      import eu.shiftforward.apso.json.Implicits.ApsoJsonObject
 
       val obj = parse("""{"a":"abc","b":{"c":2},"d":null}""").right.get
       obj.getField[Int]("b.c") must beSome(2)
@@ -141,11 +142,11 @@ class ImplicitsSpec extends Specification {
     }
 
     "provide a method to delete a field from a JSON object" in {
-      import eu.shiftforward.apso.json.Implicits.ApsoJsonObject
-
       val obj = parse("""{"a":"abc","b":{"c":2},"d":null}""").right.get
-      obj.deleteField("b.c") must beSome(parse("""{"a":"abc","b":{},"d":null}""").right.get)
-      obj.deleteField("a") must beSome(parse("""{"b":{"c":2},"d":null}""").right.get)
+
+      obj.deleteField("b.c") must beEqualTo(parse("""{"a":"abc","b":{},"d":null}""").right.get)
+      obj.deleteField("a") must beEqualTo(parse("""{"b":{"c":2},"d":null}""").right.get)
+      obj.deleteField("") must throwAn[IllegalArgumentException]
     }
   }
 }

--- a/core/src/test/scala/eu/shiftforward/apso/json/ImplicitsSpec.scala
+++ b/core/src/test/scala/eu/shiftforward/apso/json/ImplicitsSpec.scala
@@ -111,7 +111,7 @@ class ImplicitsSpec extends Specification {
       val expected =
         """{ "a": {"b": {"c": 1, "d": {"e": 3}}, "f": 5}, "g": 4 }"""
 
-      res mustEqual parse(expected).right.get
+      res mustEqual parse(expected).toTry.get
     }
 
     "provide a method to get the key set of a JsObject" in {
@@ -126,7 +126,7 @@ class ImplicitsSpec extends Specification {
     "provide a method to get the key set of a JSON object" in {
       import eu.shiftforward.apso.json.Implicits.{ ApsoJsonJsObject => _ }
 
-      val obj = parse("""{"a":1,"b":{"c":2},"d":null}""").right.get
+      val obj = parse("""{"a":1,"b":{"c":2},"d":null}""").toTry.get
       obj.flattenedKeySet(".", ignoreNull = true) === Set("a", "b.c")
       obj.flattenedKeySet(".", ignoreNull = false) === Set("a", "b.c", "d")
       obj.flattenedKeySet("/", ignoreNull = true) === Set("a", "b/c")
@@ -135,17 +135,17 @@ class ImplicitsSpec extends Specification {
 
     "provide a method to get a field from a JSON object" in {
 
-      val obj = parse("""{"a":"abc","b":{"c":2},"d":null}""").right.get
+      val obj = parse("""{"a":"abc","b":{"c":2},"d":null}""").toTry.get
       obj.getField[Int]("b.c") must beSome(2)
       obj.getField[Int]("b,c", ',') must beSome(2)
       obj.getField[String]("a") must beSome("abc")
     }
 
     "provide a method to delete a field from a JSON object" in {
-      val obj = parse("""{"a":"abc","b":{"c":2},"d":null}""").right.get
+      val obj = parse("""{"a":"abc","b":{"c":2},"d":null}""").toTry.get
 
-      obj.deleteField("b.c") must beEqualTo(parse("""{"a":"abc","b":{},"d":null}""").right.get)
-      obj.deleteField("a") must beEqualTo(parse("""{"b":{"c":2},"d":null}""").right.get)
+      obj.deleteField("b.c") must beEqualTo(parse("""{"a":"abc","b":{},"d":null}""").toTry.get)
+      obj.deleteField("a") must beEqualTo(parse("""{"b":{"c":2},"d":null}""").toTry.get)
       obj.deleteField("") must throwAn[IllegalArgumentException]
     }
   }

--- a/core/src/test/scala/eu/shiftforward/apso/json/ImplicitsSpec.scala
+++ b/core/src/test/scala/eu/shiftforward/apso/json/ImplicitsSpec.scala
@@ -97,7 +97,7 @@ class ImplicitsSpec extends Specification {
       val expected =
         """{ "a": {"b": {"c": 1, "d": {"e": 3}}, "f": 5}, "g": 4 }"""
 
-      res mustEqual parse(expected).toTry.get
+      res mustEqual parse(expected).fold(throw _, r => r)
     }
 
     "provide a method to create a circe json object from complete paths (with a custom separator)" in {
@@ -111,7 +111,7 @@ class ImplicitsSpec extends Specification {
       val expected =
         """{ "a": {"b": {"c": 1, "d": {"e": 3}}, "f": 5}, "g": 4 }"""
 
-      res mustEqual parse(expected).toTry.get
+      res mustEqual parse(expected).fold(throw _, r => r)
     }
 
     "provide a method to get the key set of a JsObject" in {
@@ -126,7 +126,7 @@ class ImplicitsSpec extends Specification {
     "provide a method to get the key set of a JSON object" in {
       import eu.shiftforward.apso.json.Implicits.{ ApsoJsonJsObject => _ }
 
-      val obj = parse("""{"a":1,"b":{"c":2},"d":null}""").toTry.get
+      val obj = parse("""{"a":1,"b":{"c":2},"d":null}""").fold(throw _, r => r)
       obj.flattenedKeySet(".", ignoreNull = true) === Set("a", "b.c")
       obj.flattenedKeySet(".", ignoreNull = false) === Set("a", "b.c", "d")
       obj.flattenedKeySet("/", ignoreNull = true) === Set("a", "b/c")
@@ -135,17 +135,17 @@ class ImplicitsSpec extends Specification {
 
     "provide a method to get a field from a JSON object" in {
 
-      val obj = parse("""{"a":"abc","b":{"c":2},"d":null}""").toTry.get
+      val obj = parse("""{"a":"abc","b":{"c":2},"d":null}""").fold(throw _, r => r)
       obj.getField[Int]("b.c") must beSome(2)
       obj.getField[Int]("b,c", ',') must beSome(2)
       obj.getField[String]("a") must beSome("abc")
     }
 
     "provide a method to delete a field from a JSON object" in {
-      val obj = parse("""{"a":"abc","b":{"c":2},"d":null}""").toTry.get
+      val obj = parse("""{"a":"abc","b":{"c":2},"d":null}""").fold(throw _, r => r)
 
-      obj.deleteField("b.c") must beEqualTo(parse("""{"a":"abc","b":{},"d":null}""").toTry.get)
-      obj.deleteField("a") must beEqualTo(parse("""{"b":{"c":2},"d":null}""").toTry.get)
+      obj.deleteField("b.c") must beEqualTo(parse("""{"a":"abc","b":{},"d":null}""").fold(throw _, r => r))
+      obj.deleteField("a") must beEqualTo(parse("""{"b":{"c":2},"d":null}""").fold(throw _, r => r))
       obj.deleteField("") must throwAn[IllegalArgumentException]
     }
   }

--- a/core/src/test/scala/eu/shiftforward/apso/json/ImplicitsSpec.scala
+++ b/core/src/test/scala/eu/shiftforward/apso/json/ImplicitsSpec.scala
@@ -1,6 +1,8 @@
 package eu.shiftforward.apso.json
 
 import org.specs2.mutable._
+import io.circe.syntax._
+import io.circe.parser._
 import spray.json.DefaultJsonProtocol._
 import spray.json._
 
@@ -82,6 +84,34 @@ class ImplicitsSpec extends Specification {
         """{ "a": {"b": {"c": 1, "d": {"e": 3}}, "f": 5}, "g": 4 }"""
 
       res mustEqual expected.parseJson
+    }
+
+    "provide a method to create a circe json object from complete paths" in {
+      val res = fromCirceFullPaths(
+        List(
+          "a.b.c" -> 1.asJson,
+          "a.b.d.e" -> 3.asJson,
+          "a.f" -> 5.asJson,
+          "g" -> 4.asJson))
+
+      val expected =
+        """{ "a": {"b": {"c": 1, "d": {"e": 3}}, "f": 5}, "g": 4 }"""
+
+      res mustEqual parse(expected).right.get
+    }
+
+    "provide a method to create a circe json object from complete paths (with a custom separator)" in {
+      val res = fromCirceFullPaths(
+        List(
+          "a-b-c" -> 1.asJson,
+          "a-b-d-e" -> 3.asJson,
+          "a-f" -> 5.asJson,
+          "g" -> 4.asJson), "-")
+
+      val expected =
+        """{ "a": {"b": {"c": 1, "d": {"e": 3}}, "f": 5}, "g": 4 }"""
+
+      res mustEqual parse(expected).right.get
     }
 
     "provide a method to get the key set of a JsObject" in {


### PR DESCRIPTION
Add new methods to manipulate circe json objects. It adds the `flattenedKeySet()` as already existed for spray and adds two methods to get fields and delete a field from an object. These are helpers to substitute somethings that were done with `JsonLenses`.