### PR TITLE
Remove spray-json from the provided scope

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ lazy val core = project.in(file("core"))
       "io.circe"                                  %% "circe-core"                     % "0.9.1",
       "io.circe"                                  %% "circe-parser"                   % "0.9.1",
       "io.github.andrebeat"                       %% "scala-pool"                     % "0.4.1",
-      "io.spray"                                  %% "spray-json"                     % "1.3.4"          % "provided",
+      "io.spray"                                  %% "spray-json"                     % "1.3.4",
       "org.apache.logging.log4j"                   % "log4j-api"                      % "2.10.0",
       "org.apache.logging.log4j"                  %% "log4j-api-scala"                % "11.0",
       "org.bouncycastle"                           % "bcpkix-jdk15on"                 % "1.59",


### PR DESCRIPTION
This PR removes `spray-json` from the provided scope. Since we provide helpers for both Circe and `spray-json` in the same classes, projects which don't provide the `spray-json` dependency and depend on Apso would raise `NoClassDefFoundError`s if we keep it in the provided scope.