### PR TITLE
Fix s3 exists method

### DIFF
--- a/core/src/main/scala/eu/shiftforward/apso/aws/S3Bucket.scala
+++ b/core/src/main/scala/eu/shiftforward/apso/aws/S3Bucket.scala
@@ -205,6 +205,15 @@ class S3Bucket(
   }.exists { _.exists(_.getKey.startsWith(key + "/")) }
 
   /**
+   * Checks whether the bucket exists
+   *
+   * @return true if the bucket exists, false otherwise.
+   */
+  def isBucket: Boolean = retry {
+    s3.doesBucketExistV2(bucketName)
+  }.getOrElse(false)
+
+  /**
    * Sets an access control list on a given Amazon S3 object.
    *
    * @param key the remote pathname for the file

--- a/core/src/main/scala/eu/shiftforward/apso/aws/S3Bucket.scala
+++ b/core/src/main/scala/eu/shiftforward/apso/aws/S3Bucket.scala
@@ -209,7 +209,7 @@ class S3Bucket(
    *
    * @return true if the bucket exists, false otherwise.
    */
-  def isBucket: Boolean = retry {
+  def bucketExists: Boolean = retry {
     s3.doesBucketExistV2(bucketName)
   }.getOrElse(false)
 

--- a/core/src/main/scala/eu/shiftforward/apso/aws/S3Bucket.scala
+++ b/core/src/main/scala/eu/shiftforward/apso/aws/S3Bucket.scala
@@ -181,18 +181,14 @@ class S3Bucket(
 
   /**
    * Checks if the file in the location specified by `key` in the bucket exists.
+   * It returns false if just checking for the bucket existence.
    *
    * @param key the remote pathname for the file
    * @return true if the file exists, false otherwise.
    */
   def exists(key: String): Boolean = retry {
-    try {
-      s3.getObjectMetadata(bucketName, key)
-    } catch {
-      case ex: AmazonS3Exception if ex.getStatusCode == 404 => false
-      case ex: Throwable => throw ex
-    }
-  }.isDefined
+    key.nonEmpty && s3.doesObjectExist(bucketName, key)
+  }.getOrElse(false)
 
   /**
    * Checks if the location specified by `key` is a directory.

--- a/core/src/main/scala/eu/shiftforward/apso/aws/S3Bucket.scala
+++ b/core/src/main/scala/eu/shiftforward/apso/aws/S3Bucket.scala
@@ -186,7 +186,12 @@ class S3Bucket(
    * @return true if the file exists, false otherwise.
    */
   def exists(key: String): Boolean = retry {
-    s3.getObjectMetadata(bucketName, key)
+    try {
+      s3.getObjectMetadata(bucketName, key)
+    } catch {
+      case ex: AmazonS3Exception if ex.getStatusCode == 404 => false
+      case ex: Throwable => throw ex
+    }
   }.isDefined
 
   /**

--- a/core/src/main/scala/eu/shiftforward/apso/io/S3FileDescriptor.scala
+++ b/core/src/main/scala/eu/shiftforward/apso/io/S3FileDescriptor.scala
@@ -111,11 +111,11 @@ case class S3FileDescriptor(
   }
 
   private lazy val isDirectoryRemote = bucket.isDirectory(builtPath)
-  private lazy val isBucketRoot = elements.isEmpty && bucket.isBucket
+  private lazy val isBucketAndExists = elements.isEmpty && bucket.bucketExists
   private var isDirectoryLocal = false
   def isDirectory: Boolean = isDirectoryLocal || isDirectoryRemote
 
-  def exists: Boolean = bucket.exists(builtPath) || isDirectory || isBucketRoot
+  def exists: Boolean = bucket.exists(builtPath) || isDirectory || isBucketAndExists
 
   def delete(): Boolean = bucket.delete(builtPath)
 

--- a/core/src/main/scala/eu/shiftforward/apso/io/S3FileDescriptor.scala
+++ b/core/src/main/scala/eu/shiftforward/apso/io/S3FileDescriptor.scala
@@ -87,8 +87,8 @@ case class S3FileDescriptor(
       }
     }
 
-    val s3Elements = listS3WithPrefix("", includeDirectories = true).map { info =>
-      removePrefix(elements, info.getKey.split("/").toList).head -> info
+    val s3Elements = listS3WithPrefix("", includeDirectories = true).flatMap { info =>
+      removePrefix(elements, info.getKey.split("/").toList).headOption.map(_ -> info)
     }.toMap
 
     s3Elements.map {
@@ -111,10 +111,11 @@ case class S3FileDescriptor(
   }
 
   private lazy val isDirectoryRemote = bucket.isDirectory(builtPath)
+  private lazy val isBucketRoot = elements.isEmpty && bucket.isBucket
   private var isDirectoryLocal = false
   def isDirectory: Boolean = isDirectoryLocal || isDirectoryRemote
 
-  def exists: Boolean = bucket.exists(builtPath)
+  def exists: Boolean = bucket.exists(builtPath) || isDirectory || isBucketRoot
 
   def delete(): Boolean = bucket.delete(builtPath)
 


### PR DESCRIPTION
If a client does not want to get a "file not found" log error he should
call the `exists` method before calling the `pull` method.