### PR TITLE
Interpret null as empty value

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ scala:
 jdk:
   - oraclejdk8
 script:
-  - sbt "set concurrentRestrictions in Global := Seq(Tags.limit(Tags.Compile, 1), Tags.limit(Tags.Test, 1))" -S-Xfatal-warnings ++$TRAVIS_SCALA_VERSION clean coverage test
+  - sbt -S-Xfatal-warnings ++$TRAVIS_SCALA_VERSION clean coverage test
 after_success:
   - sbt ++$TRAVIS_SCALA_VERSION coverageReport coverageAggregate coveralls
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ scala:
 jdk:
   - oraclejdk8
 script:
-  - sbt -S-Xfatal-warnings ++$TRAVIS_SCALA_VERSION clean coverage test
+  - sbt "set concurrentRestrictions in Global := Seq(Tags.limit(Tags.Compile, 1), Tags.limit(Tags.Test, 1))" -S-Xfatal-warnings ++$TRAVIS_SCALA_VERSION clean coverage test
 after_success:
   - sbt ++$TRAVIS_SCALA_VERSION coverageReport coverageAggregate coveralls
 cache:

--- a/core/src/main/scala/eu/shiftforward/apso/json/JsonFormatBuilder.scala
+++ b/core/src/main/scala/eu/shiftforward/apso/json/JsonFormatBuilder.scala
@@ -245,6 +245,7 @@ object JsonFormatBuilder {
   object FormatterAux {
 
     def readValue[T](obj: Map[String, JsValue], field: Field[T]) = (obj.get(field.name), field.default) match {
+      case (Some(JsNull), Some(v)) => v
       case (Some(jsValue), _) => field.jf.read(jsValue)
       case (None, Some(v)) => v
       case (None, None) => throw new DeserializationException(s"Mandatory parameter ${field.name} is missing")

--- a/core/src/main/scala/eu/shiftforward/apso/json/JsonFormatBuilder.scala
+++ b/core/src/main/scala/eu/shiftforward/apso/json/JsonFormatBuilder.scala
@@ -245,10 +245,9 @@ object JsonFormatBuilder {
   object FormatterAux {
 
     def readValue[T](obj: Map[String, JsValue], field: Field[T]) = (obj.get(field.name), field.default) match {
-      case (Some(JsNull), Some(v)) => v
-      case (Some(jsValue), _) => field.jf.read(jsValue)
-      case (None, Some(v)) => v
-      case (None, None) => throw new DeserializationException(s"Mandatory parameter ${field.name} is missing")
+      case (Some(jsValue), _) if jsValue != JsNull => field.jf.read(jsValue)
+      case (None | Some(JsNull), Some(v)) => v
+      case (None | Some(JsNull), None) => throw new DeserializationException(s"Mandatory parameter ${field.name} is missing")
     }
 
     implicit object HNilFormatter extends FormatterAux[HNil, HNil] {

--- a/core/src/test/scala/eu/shiftforward/apso/json/JsonFormatBuilderSpec.scala
+++ b/core/src/test/scala/eu/shiftforward/apso/json/JsonFormatBuilderSpec.scala
@@ -151,5 +151,17 @@ class JsonFormatBuilderSpec extends Specification {
 
       """{ "a": null }""".parseJson.convertTo[Foo](jr) mustEqual Foo(2)
     }
+
+    "throw a DeserializationException when a required field is missing" in {
+      case class Foo(a: Int)
+
+      val builder = JsonFormatBuilder()
+        .field[Int]("a")
+
+      val jr = builder.jsonReader({ case a :: HNil => Foo(a) })
+
+      """{ "a": null }""".parseJson.convertTo[Foo](jr) must throwA[DeserializationException]
+      """{}""".parseJson.convertTo[Foo](jr) must throwA[DeserializationException]
+    }
   }
 }

--- a/core/src/test/scala/eu/shiftforward/apso/json/JsonFormatBuilderSpec.scala
+++ b/core/src/test/scala/eu/shiftforward/apso/json/JsonFormatBuilderSpec.scala
@@ -140,5 +140,16 @@ class JsonFormatBuilderSpec extends Specification {
       Try("""{ "a": "asd" }""".parseJson.convertTo[Test](jf)) must beFailedTry.withThrowable[Exception]("Caught error!")
       """"string"""".parseJson.convertTo[Test](jf) mustEqual Test(0, List("string"), 0.0)
     }
+
+    "interpret null as empty values when a default value is supplied" in {
+      case class Foo(a: Int)
+
+      val builder = JsonFormatBuilder()
+        .field[Int]("a", 2)
+
+      val jr = builder.jsonReader({ case a :: HNil => Foo(a) })
+
+      """{ "a": null }""".parseJson.convertTo[Foo](jr) mustEqual Foo(2)
+    }
   }
 }


### PR DESCRIPTION
This pull request adapts `JsonFormatBuilder` to interpret a `null` as a missing field, instead of providing it to the underlying `JsonReader`.