### PR TITLE
Add Coursier as a dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,5 @@ after_success:
 cache:
   directories:
     - $HOME/.ivy2/cache
-    - $HOME/.sbt/boot
+    - $HOME/.sbt
+    - $HOME/.coursier

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
+addSbtCoursier
 addSbtPlugin("com.github.gseitz"  % "sbt-release"           % "1.0.6")
 addSbtPlugin("com.jsuereth"       % "sbt-pgp"               % "1.1.0")
 addSbtPlugin("org.scalariform"    % "sbt-scalariform"       % "1.8.0")

--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.3")


### PR DESCRIPTION
This pull request adds Coursier as a dependency. Builds using Ivy were [getting](https://travis-ci.org/velocidi/apso/builds/411326128) [stalled](https://travis-ci.org/velocidi/apso/builds/412647659) and this seems to fix the issue.