### PR TITLE
Support Arrays on the JavaConvert functions

### DIFF
--- a/core/src/main/scala/eu/shiftforward/apso/json/JsonConvert.scala
+++ b/core/src/main/scala/eu/shiftforward/apso/json/JsonConvert.scala
@@ -28,6 +28,7 @@ object JsonConvert {
     case map: java.util.Map[_, _] => Json.obj(map.asScala.map({ case (k, v) => (k.toString, toCirceJson(v)) }).toList: _*)
     case t: TraversableOnce[_] => Json.fromValues(t.map(toCirceJson).toVector)
     case t: java.lang.Iterable[_] => Json.fromValues(t.asScala.map(toCirceJson).toVector)
+    case arr: Array[_] => Json.fromValues(arr.toVector.map(toCirceJson))
     case _ => Json.fromString(obj.toString)
   }
 
@@ -47,6 +48,7 @@ object JsonConvert {
     case map: java.util.Map[_, _] => JsObject(map.asScala.map({ case (k, v) => (k.toString, toSprayJson(v)) }).toMap)
     case t: TraversableOnce[_] => JsArray(t.map(toSprayJson).toVector)
     case t: java.lang.Iterable[_] => JsArray(t.asScala.map(toSprayJson).toVector)
+    case arr: Array[_] => JsArray(arr.toVector.map(toSprayJson))
     case _ => JsString(obj.toString)
   }
 }

--- a/core/src/test/scala/eu/shiftforward/apso/json/JsonConvertSpec.scala
+++ b/core/src/test/scala/eu/shiftforward/apso/json/JsonConvertSpec.scala
@@ -21,6 +21,7 @@ class JsonConvertSpec extends Specification with EitherMatchers {
       "by converting java objects to JSON" in {
         JsonConvert.toCirceJson(Map("a" -> 2, "b" -> Map(3 -> 7)).asJava) mustEqual parse("""{ "a": 2, "b": { "3": 7 }}""").right.get
         JsonConvert.toCirceJson(List(1, 2, 3, 4).asJava) mustEqual parse("""[1, 2, 3, 4]""").right.get
+        JsonConvert.toCirceJson(Array(1, 2, 3, 4)) mustEqual parse("""[1, 2, 3, 4]""").right.get
       }
     }
 
@@ -36,6 +37,7 @@ class JsonConvertSpec extends Specification with EitherMatchers {
       "by converting java objects to JSON" in {
         JsonConvert.toSprayJson(Map("a" -> 2, "b" -> Map(3 -> 7)).asJava) mustEqual """{ "a": 2, "b": { "3": 7 }}""".parseJson
         JsonConvert.toSprayJson(List(1, 2, 3, 4).asJava) mustEqual """[1, 2, 3, 4]""".parseJson
+        JsonConvert.toSprayJson(Array(1, 2, 3, 4)) mustEqual """[1, 2, 3, 4]""".parseJson
       }
     }
   }


### PR DESCRIPTION
`Array`s do not inherit `TraversableOnce` nor `java.lang.Iterable`, so they were not supported by our `JsonConvert` methods.