### PR TITLE
Improve handling of SFTP files

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -3,6 +3,7 @@ apso {
     file-descriptor {
       sftp.max-connections-per-host = 8
       sftp.max-idle-time = 10s
+      sftp.max-lease-acquire-duration = 10s
     }
   }
 }

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -1,7 +1,7 @@
 apso {
   io {
     file-descriptor {
-      sftp.max-connections-per-host = 8
+      sftp.max-connections-per-host = 10
       sftp.max-idle-time = 10s
       sftp.max-lease-acquire-duration = 10s
     }

--- a/core/src/main/scala/com/velocidi/apso/io/SftpFileDescriptor.scala
+++ b/core/src/main/scala/com/velocidi/apso/io/SftpFileDescriptor.scala
@@ -213,6 +213,9 @@ object SftpFileDescriptor {
   private[this] val maxConnections = fdConf.getInt("apso.io.file-descriptor.sftp.max-connections-per-host")
   private[this] val maxIdleTime = Duration.fromNanos(
     fdConf.getDuration("apso.io.file-descriptor.sftp.max-idle-time").toNanos)
+  private[this] val leaseAcquireMaxDuration = Duration.fromNanos(
+    fdConf.getDuration("apso.io.file-descriptor.sftp.max-lease-acquire-duration").toNanos)
+  )
 
   private[this] val connectionPools = new ConcurrentHashMap[String, Pool[SftpClient]]()
 
@@ -284,9 +287,9 @@ object SftpFileDescriptor {
       } else p
     }
 
-    pool.tryAcquire(10.seconds) match {
+    pool.tryAcquire(leaseAcquireMaxDuration) match {
       case Some(lease) => lease
-      case None => throw new TimeoutException("Failed to acquire a SFTP client within 10 seconds.")
+      case None => throw new TimeoutException(s"Failed to acquire a SFTP client within ${leaseAcquireMaxDuration}.")
     }
   }
 

--- a/core/src/main/scala/com/velocidi/apso/io/SftpFileDescriptor.scala
+++ b/core/src/main/scala/com/velocidi/apso/io/SftpFileDescriptor.scala
@@ -170,10 +170,10 @@ case class SftpFileDescriptor(
   }
 
   def stream(offset: Long = 0L) = new InputStream {
-    private[this] val sftpLease = sftpClient()
-    private[this] val sftp = sftpLease.get()
-    private[this] val remoteFile = sftp.open(path)
-    private[this] val inner = new remoteFile.RemoteFileInputStream()
+    private[this] lazy val sftpLease = sftpClient()
+    private[this] lazy val sftp = sftpLease.get()
+    private[this] lazy val remoteFile = sftp.open(path)
+    private[this] lazy val inner = new remoteFile.RemoteFileInputStream()
     if (offset > 0) inner.skip(offset)
 
     def read() = inner.read()

--- a/core/src/main/scala/com/velocidi/apso/io/SftpFileDescriptor.scala
+++ b/core/src/main/scala/com/velocidi/apso/io/SftpFileDescriptor.scala
@@ -215,7 +215,6 @@ object SftpFileDescriptor {
     fdConf.getDuration("apso.io.file-descriptor.sftp.max-idle-time").toNanos)
   private[this] val leaseAcquireMaxDuration = Duration.fromNanos(
     fdConf.getDuration("apso.io.file-descriptor.sftp.max-lease-acquire-duration").toNanos)
-  )
 
   private[this] val connectionPools = new ConcurrentHashMap[String, Pool[SftpClient]]()
 


### PR DESCRIPTION
This PR improves the handling of SFTP files by not blocking when waiting for a connection while building an `InputStream` and by allowing the specification of a maximum duration to wait for a lease for an SFTP client.