### PR TITLE
Make deleteField safe when the field doesn't exist

### DIFF
--- a/core/src/main/scala/com/velocidi/apso/json/Implicits.scala
+++ b/core/src/main/scala/com/velocidi/apso/json/Implicits.scala
@@ -159,7 +159,7 @@ object Implicits {
     def deleteField(fieldPath: String, separator: Char = '.'): Json = {
       require(fieldPath.nonEmpty, "The field path must have value.")
 
-      getCursor(fieldPath, separator).delete.top.get
+      getCursor(fieldPath, separator).delete.top.getOrElse(json)
     }
 
     /**

--- a/core/src/test/scala/com/velocidi/apso/json/ImplicitsSpec.scala
+++ b/core/src/test/scala/com/velocidi/apso/json/ImplicitsSpec.scala
@@ -158,6 +158,8 @@ class ImplicitsSpec extends Specification {
 
       obj.deleteField("b.c") must beEqualTo(json"""{"a":"abc","b":{},"d":null}""")
       obj.deleteField("a") must beEqualTo(json"""{"b":{"c":2},"d":null}""")
+      obj.deleteField("e") must beEqualTo(obj)
+      obj.deleteField("b.c.d") must beEqualTo(obj)
       obj.deleteField("") must throwAn[IllegalArgumentException]
     }
 


### PR DESCRIPTION
I believe returning the original `JSON` object when the field to delete doesn't exist makes sense, but let me know what you think. An alternative could be to wrap the result in an `Option`.