### PR TITLE
Load fast-md5 from Maven Central

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ lazy val core = project.in(file("core"))
       "com.j256.simplejmx"                         % "simplejmx"                      % "1.15",
       "com.jcraft"                                 % "jzlib"                          % "1.1.3",
       "com.mashape.unirest"                        % "unirest-java"                   % "1.4.9",
-      "com.twmacinta"                              % "fast-md5"                       % "2.7.1",
+      "com.joyent.util"                            % "fast-md5"                       % "2.7.1",
       "com.typesafe"                               % "config"                         % "1.3.3"          % "provided",
       "com.typesafe.akka"                         %% "akka-actor"                     % "2.5.18"         % "provided",
       "com.typesafe.akka"                         %% "akka-http"                      % "10.1.5"         % "provided",


### PR DESCRIPTION
Uses the [Joyent release of fast-md5](https://github.com/joyent/java-fast-md5), which is published on Maven Central.