### PR TITLE
Correct the isDirectory behavior in S3

### DIFF
--- a/core/src/main/scala/com/velocidi/apso/io/S3FileDescriptor.scala
+++ b/core/src/main/scala/com/velocidi/apso/io/S3FileDescriptor.scala
@@ -111,7 +111,11 @@ case class S3FileDescriptor(
     S3FileDescriptor(bucket, elements.dropRight(1) :+ f(name))
   }
 
-  private lazy val isDirectoryRemote = bucket.isDirectory(builtPath)
+  private lazy val isDirectoryRemote = {
+    // the bucket itself is considered a directory
+    if (elements.isEmpty) true
+    else bucket.isDirectory(builtPath)
+  }
   private lazy val isBucketAndExists = elements.isEmpty && bucket.bucketExists
   private var isDirectoryLocal = false
   def isDirectory: Boolean = isDirectoryLocal || isDirectoryRemote


### PR DESCRIPTION
This makes sure that the bucket itself is recognized as a directory.
```
# before
scala> FileDescriptor("s3://some-bucket").isDirectory
res0: Boolean = false
# after
scala> FileDescriptor("s3://some-bucket").isDirectory
res0: Boolean = true
```