### PR TITLE
Change CI build to use `openjdk8` instead of `oraclejdk8`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ scala:
   - 2.11.12
   - 2.12.7
 jdk:
-  - oraclejdk8
+  - openjdk8
 script:
   - sbt -S-Xfatal-warnings ++$TRAVIS_SCALA_VERSION clean coverage test
 after_success:


### PR DESCRIPTION
This PR changes the CI build to use `openjdk8` instead of `oraclejdk8`.

Our build was moved to Xenial, which doesn't support `oraclejdk8` (https://travis-ci.community/t/expected-feature-release-number-in-range-of-9-to-12-but-got-8-installing-oraclejdk8/1345).