### PR TITLE
Fix external scaladoc references

### DIFF
--- a/aws/src/main/scala/com/velocidi/apso/aws/CredentialStore.scala
+++ b/aws/src/main/scala/com/velocidi/apso/aws/CredentialStore.scala
@@ -3,9 +3,8 @@ package com.velocidi.apso.aws
 import com.amazonaws.auth._
 
 /**
- * An object that serves as an endpoint for the retrieval of AWS credentials from available
- * configurations. In particular, it extends the chain in
- * [[com.amazonaws.auth.DefaultAWSCredentialsProviderChain]] with the retrieval of AWS credentials
+ * An object that serves as an endpoint for the retrieval of AWS credentials from available configurations. In
+ * particular, it extends the chain in the `DefaultAWSCredentialsProviderChain` with the retrieval of AWS credentials
  * through the default typesafe configuration file (typically application.conf).
  */
 object CredentialStore extends AWSCredentialsProviderChain(

--- a/aws/src/main/scala/com/velocidi/apso/aws/S3Bucket.scala
+++ b/aws/src/main/scala/com/velocidi/apso/aws/S3Bucket.scala
@@ -18,9 +18,8 @@ import com.velocidi.apso.aws.S3Bucket.S3ObjectDownloader
 import com.velocidi.apso.{ Logging, TryWith }
 
 /**
- * A representation of an Amazon's S3 bucket. This class wraps an
- * [[com.amazonaws.services.s3.AmazonS3Client]] and provides a higher level interface for pushing
- * and pulling files to and from a bucket.
+ * A representation of an Amazon's S3 bucket. This class wraps an `AmazonS3Client` and provides a higher level
+ * interface for pushing and pulling files to and from a bucket.
  *
  * @param bucketName          the name of the bucket
  * @param credentialsProvider optional AWS credentials provider to use (since AWSCredentials are not serializable).

--- a/build.sbt
+++ b/build.sbt
@@ -68,6 +68,8 @@ lazy val commonSettings = Seq(
     }
   },
 
+  autoAPIMappings := true,
+
   publishTo := {
     val nexus = "https://oss.sonatype.org/"
     if (isSnapshot.value) Some("snapshots" at nexus + "content/repositories/snapshots")

--- a/encryption/src/main/scala/com/velocidi/apso/encryption/EncryptionUtils.scala
+++ b/encryption/src/main/scala/com/velocidi/apso/encryption/EncryptionUtils.scala
@@ -14,7 +14,7 @@ object BouncyCastleInitializer {
 }
 
 /**
- * Loads and provide a [[BouncyCastleProvider]] and provides utility methods to encode in base64, load keystores and create
+ * Loads and provide a `BouncyCastleProvider` and provides utility methods to encode in base64, load keystores and create
  * keys from raw password input.
  */
 trait EncryptionUtils extends EncryptionErrorHandling {

--- a/json/src/main/scala/com/velocidi/apso/json/ExtraJsonProtocol.scala
+++ b/json/src/main/scala/com/velocidi/apso/json/ExtraJsonProtocol.scala
@@ -16,7 +16,7 @@ import spray.json._
 import squants.market.{ Currency, MoneyContext }
 
 /**
- * Provides additional JsonFormats not available in the [[spray.json.DefaultJsonProtocol]].
+ * Provides additional JsonFormats not available in the `DefaultJsonProtocol`.
  */
 object ExtraJsonProtocol
   extends ExtraTimeJsonProtocol


### PR DESCRIPTION
Sets `autoAPIMappings := true` and removes references to javadoc entries/non-existing scaladoc entries.

This should fix the fatal warnings when trying to publish a new version of apso.