### PR TITLE
Change Retry to use NonFatal extractors only

### DIFF
--- a/core/src/main/scala/com/velocidi/apso/Retry.scala
+++ b/core/src/main/scala/com/velocidi/apso/Retry.scala
@@ -2,6 +2,7 @@ package com.velocidi.apso
 
 import scala.concurrent.duration._
 import scala.concurrent.{ ExecutionContext, Future }
+import scala.util.control.NonFatal
 import scala.util.{ Failure, Success, Try }
 
 /**
@@ -27,7 +28,7 @@ object Retry {
         f
       case _ =>
         f recoverWith {
-          case _: Throwable =>
+          case NonFatal(_) => // it would be indifferent to use a Throwable here because Futures don't catch Fatal exceptions
             inBetweenSleep.foreach(d => Thread.sleep(d.toMillis))
             retryFuture[T](maxRetries - 1, inBetweenSleep)(f)
         }
@@ -51,7 +52,7 @@ object Retry {
       case _ =>
         Try(f) match {
           case res @ Success(_) => res
-          case Failure(_) =>
+          case Failure(NonFatal(_)) => // it would be indifferent to use a Throwable here because Try don't catch Fatal exceptions
             inBetweenSleep.foreach(d => Thread.sleep(d.toMillis))
             retry[T](maxRetries - 1, inBetweenSleep)(f)
         }

--- a/core/src/test/scala/com/velocidi/apso/RetrySpec.scala
+++ b/core/src/test/scala/com/velocidi/apso/RetrySpec.scala
@@ -2,8 +2,8 @@ package com.velocidi.apso
 
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.mutable.Specification
-
 import scala.concurrent.Future
+import scala.util.Failure
 
 class RetrySpec(implicit ee: ExecutionEnv) extends Specification with FutureExtraMatchers {
 
@@ -64,6 +64,28 @@ class RetrySpec(implicit ee: ExecutionEnv) extends Specification with FutureExtr
       eventually(f must beAFailedTry)
 
       attempts must beEqualTo(1 + retries) // 1 attempt + 10 retries
+    }
+
+    "don't retry a doomed function throwing a Fatal exception" in {
+      var attempts = 0
+      val retries = 10
+
+      val f = try {
+        Retry.retry[Any](retries) {
+          attempts = attempts + 1
+          throw new OutOfMemoryError("Doomed")
+        }
+      } catch {
+        case _: OutOfMemoryError =>
+          Failure(new RuntimeException("Failed previously with out of memory!"))
+      }
+
+      eventually(f must beAFailedTry.like {
+        case ex: RuntimeException =>
+          ex.getMessage must beEqualTo("Failed previously with out of memory!")
+      })
+
+      attempts must beEqualTo(1) // 1 attempt
     }
   }
 }


### PR DESCRIPTION
Functionally, this remains the same, as the containers we were using already did not catch any "fatal" exceptions. This is mostly for documentation purposes.