### PR TITLE
Control lifecycle of `ElasticClient` from within `ElasticsearchBulkInserter`

### DIFF
--- a/elasticsearch/src/test/resources/application.conf
+++ b/elasticsearch/src/test/resources/application.conf
@@ -1,0 +1,4 @@
+akka {
+  log-dead-letters = 0
+  log-dead-letters-during-shutdown = off
+}

--- a/elasticsearch/src/test/scala/com/velocidi/apso/elasticsearch/ElasticsearchBulkInserterSpec.scala
+++ b/elasticsearch/src/test/scala/com/velocidi/apso/elasticsearch/ElasticsearchBulkInserterSpec.scala
@@ -19,12 +19,12 @@ class ElasticsearchBulkInserterSpec(implicit ee: ExecutionEnv) extends AkkaSpeci
 
   def testBulkInserterConfig(maxBufferSize: Int, flushFreq: FiniteDuration) = {
     Elasticsearch(
-      "localhost",
-      httpPort,
-      false,
-      None,
-      None,
-      Some(Elasticsearch.BulkInserter(
+      host = "localhost",
+      port = httpPort,
+      useHttps = false,
+      username = None,
+      password = None,
+      bulkInserter = Some(Elasticsearch.BulkInserter(
         flushFrequency = flushFreq,
         esDownCheckFrequency = 10.seconds,
         maxBufferSize = maxBufferSize,

--- a/elasticsearch/src/test/scala/com/velocidi/apso/elasticsearch/ElasticsearchBulkInserterSpec.scala
+++ b/elasticsearch/src/test/scala/com/velocidi/apso/elasticsearch/ElasticsearchBulkInserterSpec.scala
@@ -3,7 +3,6 @@ package com.velocidi.apso.elasticsearch
 import scala.concurrent.duration._
 
 import akka.actor._
-import akka.testkit._
 import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.RequestSuccess
 import com.sksamuel.elastic4s.requests.searches._
@@ -12,7 +11,7 @@ import io.circe.syntax._
 import net.ruippeixotog.akka.testkit.specs2.mutable.AkkaSpecification
 import org.specs2.concurrent.ExecutionEnv
 
-import com.velocidi.apso.elasticsearch.ElasticsearchBulkInserter.{ ElasticsearchDown, ElasticsearchUp, Insert }
+import com.velocidi.apso.elasticsearch.ElasticsearchBulkInserter.Insert
 import com.velocidi.apso.elasticsearch.config.Elasticsearch
 
 class ElasticsearchBulkInserterSpec(implicit ee: ExecutionEnv) extends AkkaSpecification with ElasticsearchTestKit {
@@ -51,11 +50,8 @@ class ElasticsearchBulkInserterSpec(implicit ee: ExecutionEnv) extends AkkaSpeci
 
     "collect events and send them in bulk to Elasticsearch after a buffer is filled" in {
       val msgIndex = "test-index-1"
-      val probe = TestProbe()
 
-      val bulkInserter = testBulkInserter(maxBufferSize = 5, esStateListener = probe.ref)
-
-      probe must receiveWithin(10.seconds)(ElasticsearchUp)
+      val bulkInserter = testBulkInserter(maxBufferSize = 5)
 
       for (i <- 1 to 3) bulkInserter ! Insert(Json.obj("id" := i), msgIndex)
       esClient.execute(searchQuery(msgIndex)).map(_.result.totalHits) must not(be_==(3).awaitFor(5.seconds).eventually(5, 2.seconds))
@@ -66,11 +62,8 @@ class ElasticsearchBulkInserterSpec(implicit ee: ExecutionEnv) extends AkkaSpeci
 
     "collect events and send them in bulk to Elasticsearch after a periodic flush occurs" in {
       val msgIndex = "test-index-2"
-      val probe = TestProbe()
 
-      val bulkInserter = testBulkInserter(flushFreq = 10.seconds, esStateListener = probe.ref)
-
-      probe must receiveWithin(10.seconds)(ElasticsearchUp)
+      val bulkInserter = testBulkInserter(flushFreq = 10.seconds)
 
       for (i <- 1 to 5) bulkInserter ! Insert(Json.obj("id" := i), msgIndex)
 
@@ -80,35 +73,10 @@ class ElasticsearchBulkInserterSpec(implicit ee: ExecutionEnv) extends AkkaSpeci
       esClient.execute(searchQuery(msgIndex)).map(_.result.totalHits) must be_==(5).awaitFor(5.seconds).eventually(10, 2.seconds)
     }
 
-    "notify an actor when Elasticsearch changes its availability status" in {
-      val msgIndex = "test-index-3"
-      val probe = TestProbe()
-
-      val bulkInserter = testBulkInserter(maxBufferSize = 5, esStateListener = probe.ref)
-
-      probe must receiveWithin(10.seconds)(ElasticsearchUp)
-
-      for (i <- 1 to 3) bulkInserter ! Insert(Json.obj("id" := i), msgIndex)
-      esClient.execute(searchQuery(msgIndex)).map(_.result.totalHits) must be_==(0).awaitFor(5.seconds).eventually(10, 2.seconds)
-
-      esClient.execute(closeIndex(msgIndex)).await
-      probe must not(receiveMessage)
-
-      for (i <- 4 to 5) bulkInserter ! Insert(Json.obj("id" := i), msgIndex)
-      probe must receive(ElasticsearchDown)
-
-      esClient.execute(openIndex(msgIndex)).await
-      probe must receiveWithin(15.seconds)(ElasticsearchUp)
-      esClient.execute(searchQuery(msgIndex)).map(_.result.totalHits) must be_==(5).awaitFor(5.seconds).eventually(10, 2.seconds)
-    }
-
     "correctly handle errors and retry document insertion errors" in {
       val msgIndex = "test-index-4"
-      val probe = TestProbe()
 
-      val bulkInserter = testBulkInserter(maxBufferSize = 2, esStateListener = probe.ref)
-
-      probe must receiveWithin(10.seconds)(ElasticsearchUp)
+      val bulkInserter = testBulkInserter(maxBufferSize = 2)
 
       // use a mapping that does not allow for extra fields other than the "name" one
       esClient.execute(putMapping(msgIndex) rawSource """{"dynamic":"strict","properties":{"name":{"type":"text"}}}""") must


### PR DESCRIPTION
Disables supplying an external `ElasticClient` to `ElasticsearchBulkInserter` and makes sure its lifecycle (creation and closing) follows the lifecycle of the actor.

Incidentally, this also starts providing the complete `Throwables` to log entries, so that it becomes possible to have access to a stack trace.