### PR TITLE
Use `DateTime.parse` in `DateTime` `Decoder`

### DIFF
--- a/json/src/main/scala/com/velocidi/apso/json/ExtraJsonProtocol.scala
+++ b/json/src/main/scala/com/velocidi/apso/json/ExtraJsonProtocol.scala
@@ -167,7 +167,7 @@ trait ExtraMiscJsonProtocol {
     def apply(a: DateTime): Json = stringEncoder.apply(printer.print(a))
   }
   implicit val dateTimeDecoder: Decoder[DateTime] =
-    Decoder[String].emapTry(v => Try(new DateTime(v)))
+    Decoder[String].emapTry(v => Try(DateTime.parse(v)))
 
   @deprecated("This will be removed in a future version.", "2019/10/23")
   implicit object LocalDateFormat extends JsonFormat[LocalDate] {

--- a/json/src/test/scala/com/velocidi/apso/json/ExtraJsonProtocolSpec.scala
+++ b/json/src/test/scala/com/velocidi/apso/json/ExtraJsonProtocolSpec.scala
@@ -168,7 +168,7 @@ class ExtraJsonProtocolSpec extends Specification {
     }
 
     "provide an Encoder and Decoder for DateTime" in {
-      val dateTime = new DateTime("2016-01-01")
+      val dateTime = DateTime.parse("2016-01-01T00:00:00.000Z")
       val dateTimeJsonString = json""""2016-01-01T00:00:00.000Z""""
 
       dateTime.asJson mustEqual dateTimeJsonString


### PR DESCRIPTION
The `DateTime` constructor will use the system timezone, and its behavior won't be changed for compatibility reasons (https://stackoverflow.com/a/12203707/274482).