### PR TITLE
Introduce extension method emapPrettyTry to circe's Decoder

### DIFF
--- a/json/src/main/scala/com/velocidi/apso/json/ExtraJsonProtocol.scala
+++ b/json/src/main/scala/com/velocidi/apso/json/ExtraJsonProtocol.scala
@@ -13,6 +13,8 @@ import org.joda.time.format.ISODateTimeFormat
 import org.joda.time.{ Duration => _, _ }
 import squants.market.{ Currency, MoneyContext }
 
+import com.velocidi.apso.json.syntax._
+
 /**
  * Provides additional JsonFormats not available in the `DefaultJsonProtocol`.
  */
@@ -28,8 +30,8 @@ trait ExtraTimeJsonProtocol {
   implicit val finiteDurationEncoder: Encoder[FiniteDuration] =
     Encoder.forProduct1("milliseconds")(_.toMillis)
   implicit val finiteDurationDecoder: Decoder[FiniteDuration] =
-    Decoder[Long].emapTry(v => tryToParseDuration(v.toString)) or
-      Decoder[String].emapTry(v => tryToParseDuration(v)) or
+    Decoder[Long].emapPrettyTry(v => tryToParseDuration(v.toString)) or
+      Decoder[String].emapPrettyTry(v => tryToParseDuration(v)) or
       Decoder.forProduct1[FiniteDuration, Long]("milliseconds")(_.millis) or
       Decoder.forProduct1[FiniteDuration, Long]("seconds")(_.seconds) or
       Decoder.forProduct1[FiniteDuration, Long]("minutes")(_.minutes) or
@@ -44,7 +46,7 @@ trait ExtraTimeJsonProtocol {
   implicit val periodEncoder: Encoder[Period] =
     Encoder[String].contramap(_.toString)
   implicit val periodDecoder: Decoder[Period] =
-    Decoder[String].emapTry(v => Try(new Period(v)))
+    Decoder[String].emapPrettyTry(v => Try(new Period(v)))
 }
 
 trait ExtraHttpJsonProtocol {
@@ -52,14 +54,14 @@ trait ExtraHttpJsonProtocol {
   implicit val uriEncoder: Encoder[URI] =
     Encoder[String].contramap(_.toString)
   implicit val uriDecoder: Decoder[URI] =
-    Decoder[String].emapTry(v => Try(new URI(v)))
+    Decoder[String].emapPrettyTry(v => Try(new URI(v)))
 }
 
 trait ExtraMiscJsonProtocol {
   implicit val configEncoder: Encoder[Config] =
     Encoder[Json].contramap(conf => parse(conf.root.render(ConfigRenderOptions.concise())).fold(throw _, identity))
   implicit val configDecoder: Decoder[Config] =
-    Decoder[Json].emapTry(json => Try(ConfigFactory.parseString(json.toString)))
+    Decoder[Json].emapPrettyTry(json => Try(ConfigFactory.parseString(json.toString)))
 
   implicit val dateTimeEncoder: Encoder[DateTime] = new Encoder[DateTime] {
     private val stringEncoder = Encoder[String]
@@ -68,14 +70,14 @@ trait ExtraMiscJsonProtocol {
     def apply(a: DateTime): Json = stringEncoder.apply(printer.print(a))
   }
   implicit val dateTimeDecoder: Decoder[DateTime] =
-    Decoder[String].emapTry(v => Try(DateTime.parse(v).toDateTime(DateTimeZone.UTC)))
+    Decoder[String].emapPrettyTry(v => Try(DateTime.parse(v).toDateTime(DateTimeZone.UTC)))
 
   implicit val localDateEncoder: Encoder[LocalDate] =
     Encoder[String].contramap(_.toString)
   implicit val localDateDecoder: Decoder[LocalDate] =
-    Decoder[String].emapTry(v => Try(new LocalDate(v)))
+    Decoder[String].emapPrettyTry(v => Try(new LocalDate(v)))
 
-  implicit def currencyDecoder(implicit moneyContext: MoneyContext): Decoder[Currency] = Decoder[String].emapTry(Currency(_))
+  implicit def currencyDecoder(implicit moneyContext: MoneyContext): Decoder[Currency] = Decoder[String].emapPrettyTry(Currency(_))
   implicit val currencyEncoder: Encoder[Currency] = Encoder[String].contramap(_.toString)
 
   /**

--- a/json/src/main/scala/com/velocidi/apso/json/syntax/package.scala
+++ b/json/src/main/scala/com/velocidi/apso/json/syntax/package.scala
@@ -1,0 +1,20 @@
+package com.velocidi.apso.json
+
+import scala.util.Try
+
+import io.circe.Decoder
+
+package object syntax {
+  implicit class CirceDecoderExtras[A](val decoder: Decoder[A]) extends AnyVal {
+
+    /**
+     * Performs similarly to `emapTry` but in case of failure it exclusively uses the Throwable's message
+     * to create the DecodingFailure message whereas `emapTry` would use the message+stacktrace.
+     * Related issue: https://github.com/circe/circe/issues/306
+     *
+     * @param f a function returning a Try of value
+     */
+    def emapPrettyTry[B](f: A => Try[B]): Decoder[B] =
+      decoder.emap(f(_).toEither.left.map(_.getMessage))
+  }
+}

--- a/json/src/test/scala/com/velocidi/apso/json/syntax/ExtensionMethodsSpec.scala
+++ b/json/src/test/scala/com/velocidi/apso/json/syntax/ExtensionMethodsSpec.scala
@@ -1,0 +1,33 @@
+package com.velocidi.apso.json.syntax
+
+import scala.util.{ Failure, Success }
+
+import io.circe.CursorOp.DownField
+import io.circe.Decoder.Result
+import io.circe.{ Decoder, DecodingFailure, Json }
+import io.circe.syntax._
+import org.specs2.mutable.Specification
+
+class ExtensionMethodsSpec extends Specification {
+
+  "emapPrettyTry" should {
+    case class TestClass(str: String)
+    implicit val decoder: Decoder[TestClass] = Decoder[String].emapPrettyTry { s =>
+      if (s == "error") Failure(new Exception("foo"))
+      else Success(TestClass(s))
+    }
+
+    "return the correct value if f returns a successful Try" in {
+      decoder.decodeJson(Json.fromString("good")) must beRight(TestClass("good"))
+    }
+
+    "return a DecodingFailure without a stack trace if f returns a failure Try" in {
+      decoder.decodeJson(Json.fromString("error")) must beLeft(DecodingFailure("foo", List.empty))
+    }
+
+    "return a DecodingFailure with corrects ops if f returns a failure Try in a nested json decoding" in {
+      val result: Result[TestClass] = Json.obj("1" -> Json.obj("2" := "error")).hcursor.downField("1").downField("2").as[TestClass]
+      result must beLeft(DecodingFailure("foo", List(DownField("2"), DownField("1"))))
+    }
+  }
+}


### PR DESCRIPTION
Using `emapTry` to create a Decoder will result in the stack trace being serialized along with the throwable's message. 

This new method behaviour is similar to `emapTry` but in case of failure it exclusively uses the Throwable's message to create the DecodingFailure message whereas `emapTry` would use the message+stacktrace.
Related issue: https://github.com/circe/circe/issues/306

It also changes all occurrences of `emapTry` to `emapPrettyTry` in the codebase.