### PR TITLE
Add check on CI for uncommitted `mdoc` changes

### DIFF
--- a/.github/workflows/compile_test.yml
+++ b/.github/workflows/compile_test.yml
@@ -41,3 +41,5 @@ jobs:
         key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
     - name: Run tests
       run: sbt -Dsbt.color=always ++$SCALA_VERSION test:compile test
+    - name: Check mdoc for uncommited changes
+      run: sbt -Dsbt.color=always "docs/mdoc --check"

--- a/.github/workflows/compile_test.yml
+++ b/.github/workflows/compile_test.yml
@@ -41,5 +41,5 @@ jobs:
         key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
     - name: Run tests
       run: sbt -Dsbt.color=always ++$SCALA_VERSION test:compile test
-    - name: Check mdoc for uncommited changes
+    - name: Check mdoc for uncommitted changes
       run: sbt -Dsbt.color=always "docs/mdoc --check"


### PR DESCRIPTION
This adds an additional step on CI that throws an error if there is a change on the docs that wasn't run and committed.