### PR TITLE
Point build status badge to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Compile and Test
+name: CI
 
 on: [push]
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center"><img src="https://raw.githubusercontent.com/velocidi/apso/master/apso.png"/></p>
 
-# Apso [![Build Status](https://travis-ci.org/velocidi/apso.svg?branch=master)](https://travis-ci.org/velocidi/apso) [![Maven Central](https://img.shields.io/maven-central/v/com.velocidi/apso_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/com.velocidi/apso_2.12)
+# Apso [![Build Status](https://github.com/velocidi/apso/workflows/CI/badge.svg?branch=master)](https://github.com/velocidi/apso/actions?query=workflow%3ACI+branch%3Amaster) [![Maven Central](https://img.shields.io/maven-central/v/com.velocidi/apso_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/com.velocidi/apso_2.12)
 
 Apso is Velocidi's collection of Scala utility libraries. It provides a series of useful methods.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 <p align="center"><img src="https://raw.githubusercontent.com/velocidi/apso/master/apso.png"/></p>
 
-# Apso [![Build Status](https://travis-ci.org/velocidi/apso.svg?branch=master)](https://travis-ci.org/velocidi/apso) [![Maven Central](https://img.shields.io/maven-central/v/com.velocidi/apso_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/com.velocidi/apso_2.12)
+# Apso [![Build Status](https://github.com/velocidi/apso/workflows/CI/badge.svg?branch=master)](https://github.com/velocidi/apso/actions?query=workflow%3ACI+branch%3Amaster) [![Maven Central](https://img.shields.io/maven-central/v/com.velocidi/apso_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/com.velocidi/apso_2.12)
 
 Apso is Velocidi's collection of Scala utility libraries. It provides a series of useful methods.
 


### PR DESCRIPTION
This PR updates the build status badge to point to the GitHub Actions build, since we're no longer using Travis. Incidentally, this also renames the workflow to "CI", since it looks better on the badge.