### PR TITLE
Update Circe to 0.13.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
     val AkkaTestkitSpecs2       = "0.2.4"
     val Aws                     = "1.11.553"
     val BouncyCastle            = "1.64"
-    val Circe                   = "0.12.3"
+    val Circe                   = "0.13.0"
     val CommonsCodec            = "1.13"
     val ConcurrentLinkedHashMap = "1.4.2"
     val Elastic4s               = "7.1.2"


### PR DESCRIPTION
This PR updates circe-core, circe-generic and circe-parser to 0.13.0. circe-parser 0.13.0 is not binary compatible with 0.12.x, so this update is important for downstream users.