### PR TITLE
Add an `isLocal` flag to `FileDescriptor`

### DIFF
--- a/io/src/main/scala/com/velocidi/apso/io/FileDescriptor.scala
+++ b/io/src/main/scala/com/velocidi/apso/io/FileDescriptor.scala
@@ -23,6 +23,11 @@ trait FileDescriptor {
   def name: String
 
   /**
+   * Whether the file descriptor is used to access a local file.
+   */
+  def isLocal: Boolean
+
+  /**
    * The size of the file associated with the file descriptor.
    */
   def size: Long

--- a/io/src/main/scala/com/velocidi/apso/io/LocalFileDescriptor.scala
+++ b/io/src/main/scala/com/velocidi/apso/io/LocalFileDescriptor.scala
@@ -22,7 +22,7 @@ case class LocalFileDescriptor(initialPath: String) extends FileDescriptor with 
 
   lazy val name: String = file.getName
 
-  def isLocal: Boolean = true
+  val isLocal: Boolean = true
 
   lazy val file = Paths.get(initialPath).normalize().toAbsolutePath.toFile
 

--- a/io/src/main/scala/com/velocidi/apso/io/LocalFileDescriptor.scala
+++ b/io/src/main/scala/com/velocidi/apso/io/LocalFileDescriptor.scala
@@ -22,6 +22,8 @@ case class LocalFileDescriptor(initialPath: String) extends FileDescriptor with 
 
   lazy val name: String = file.getName
 
+  def isLocal: Boolean = true
+
   lazy val file = Paths.get(initialPath).normalize().toAbsolutePath.toFile
 
   def isDirectory: Boolean = file.isDirectory

--- a/io/src/main/scala/com/velocidi/apso/io/RemoteFileDescriptor.scala
+++ b/io/src/main/scala/com/velocidi/apso/io/RemoteFileDescriptor.scala
@@ -8,6 +8,7 @@ trait RemoteFileDescriptor { this: FileDescriptor =>
 
   lazy val name: String = elements.lastOption.getOrElse("")
   lazy val path: String = root + "/" + elements.mkString("/")
+  def isLocal: Boolean = false
 
   private def sanitize(segment: String): Option[String] = {
     val whiteSpaceValidated = segment.trim match {

--- a/io/src/main/scala/com/velocidi/apso/io/RemoteFileDescriptor.scala
+++ b/io/src/main/scala/com/velocidi/apso/io/RemoteFileDescriptor.scala
@@ -8,7 +8,7 @@ trait RemoteFileDescriptor { this: FileDescriptor =>
 
   lazy val name: String = elements.lastOption.getOrElse("")
   lazy val path: String = root + "/" + elements.mkString("/")
-  def isLocal: Boolean = false
+  val isLocal: Boolean = false
 
   private def sanitize(segment: String): Option[String] = {
     val whiteSpaceValidated = segment.trim match {

--- a/io/src/test/scala/com/velocidi/apso/io/FileDescriptorSpec.scala
+++ b/io/src/test/scala/com/velocidi/apso/io/FileDescriptorSpec.scala
@@ -24,6 +24,13 @@ class FileDescriptorSpec extends Specification with CustomMatchers {
       FileDescriptor("sftp://valid-host.com/tmp/path", fdConfig) mustEqual SftpFileDescriptor("valid-host.com/tmp/path", fdConfig.sftp)
     }
 
+    "correctly identify itself as local or non-local" in {
+      FileDescriptor("file:///tmp/folder").isLocal must beTrue
+      FileDescriptor("s3://tmp/path").isLocal must beFalse
+      FileDescriptor("sftp://localhost/tmp/path", fdConfig).isLocal must beFalse
+      FileDescriptor("sftp://valid-host.com/tmp/path", fdConfig).isLocal must beFalse
+    }
+
     "be serializable" in {
       FileDescriptor("file:///tmp/folder") must beSerializable
       FileDescriptor("s3://tmp/path") must beSerializable


### PR DESCRIPTION
This adds an `isLocal` flag to `FileDescriptor` enabling quickly identifying an FD as either using to access a local file or not.