### PR TITLE
Fix CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 1.8 and SBT
-      uses: olafurpg/setup-scala@v7
+      uses: olafurpg/setup-scala@v10
       with:
-        java-version: openjdk@1.8
+        java-version: adopt@1.8
     - name: Cache Coursier
       uses: actions/cache@v1
       with:


### PR DESCRIPTION
The previous version of olafurpg/setup-scala was using deprecated GitHub Actions commands.