### PR TITLE
Make indexing failures be sent only when retries are exhausted

### DIFF
--- a/elasticsearch/src/main/scala/com/velocidi/apso/elasticsearch/ElasticsearchBulkInserter.scala
+++ b/elasticsearch/src/main/scala/com/velocidi/apso/elasticsearch/ElasticsearchBulkInserter.scala
@@ -72,11 +72,11 @@ class ElasticsearchBulkInserter(
     val tryCount = tryCountMap.getOrElse(msg, 0) + 1
 
     if (tryCount > maxTryCount) {
+      msg.sender ! Status.Failure(new Throwable(s"Error inserting document in Elasticsearch: ${item.error}"))
       tryCountMap.remove(msg)
       logErrorOrWarning(s"Error inserting document in Elasticsearch: $item")
       Nil
     } else {
-      msg.sender ! Status.Failure(new Throwable(s"Error inserting document in Elasticsearch: ${item.error}"))
       tryCountMap(msg) = tryCount
       log.info(
         "Error inserting document in Elasticsearch: {}. Will retry {} more times",

--- a/elasticsearch/src/test/scala/com/velocidi/apso/elasticsearch/ElasticsearchBulkInserterSpec.scala
+++ b/elasticsearch/src/test/scala/com/velocidi/apso/elasticsearch/ElasticsearchBulkInserterSpec.scala
@@ -116,60 +116,62 @@ class ElasticsearchBulkInserterSpec(implicit ee: ExecutionEnv) extends AkkaSpeci
     }
 
     "correctly send error back to client only when retries are exhausted" in {
+      "when the buffer maximum size is reached" in {
+        val msgIndex = "test-index-5"
+        // maxTryCount is 3
+        val bulkInserter = testBulkInserter(maxBufferSize = 2, flushFreq = 1.day)
 
-      // NOTICE: trying on a setting in which the retries are triggered by the buffer reaching its max capacity
-      val msgIndex1 = "test-index-5"
-      // maxTryCount is 3
-      val bulkInserter1 = testBulkInserter(maxBufferSize = 2, flushFreq = 1.day)
+        // use a mapping that does not allow for extra fields other than the "name" one
+        esClient.execute(putMapping(msgIndex) rawSource """{"dynamic":"strict","properties":{"name":{"type":"text"}}}""") must
+          beAnInstanceOf[RequestSuccess[_]].awaitFor(5.seconds)
 
-      // use a mapping that does not allow for extra fields other than the "name" one
-      esClient.execute(putMapping(msgIndex1) rawSource """{"dynamic":"strict","properties":{"name":{"type":"text"}}}""") must
-        beAnInstanceOf[RequestSuccess[_]].awaitFor(5.seconds)
+        // insert valid documents
+        bulkInserter ! Insert(Json.obj("name" := "test1"), msgIndex)
+        bulkInserter ! Insert(Json.obj("name" := "test2"), msgIndex)
+        numberOfHits(msgIndex) must be_==(2).retry(eventuallyRetries = 30)
 
-      // insert valid documents
-      bulkInserter1 ! Insert(Json.obj("name" := "test1"), msgIndex1)
-      bulkInserter1 ! Insert(Json.obj("name" := "test2"), msgIndex1)
-      numberOfHits(msgIndex1) must be_==(2).retry(eventuallyRetries = 30)
+        // insert an invalid document that will be retried
+        val probe = TestProbe()
+        bulkInserter.!(Insert(Json.obj("name" := "test3", "other" := "dynamic_field_value"), msgIndex))(probe.ref)
+        numberOfHits(msgIndex) must be_==(2).retry(eventuallyRetries = 30)
+        probe must not(receive.like { case Status.Failure(_) => ok })
 
-      // insert an invalid document that will be retried
-      val probe = TestProbe()
-      bulkInserter1.!(Insert(Json.obj("name" := "test3", "other" := "dynamic_field_value"), msgIndex1))(probe.ref)
-      numberOfHits(msgIndex1) must be_==(2).retry(eventuallyRetries = 30)
-      probe must not(receive.like { case Status.Failure(_) => ok })
+        // after this valid one, the failed one above will be retried...
+        bulkInserter ! Insert(Json.obj("name" := "test4"), msgIndex)
+        numberOfHits(msgIndex) must be_==(3).retry(eventuallyRetries = 30)
+        probe must not(receive.like { case Status.Failure(_) => ok })
 
-      // after this valid one, the failed one above will be retried...
-      bulkInserter1 ! Insert(Json.obj("name" := "test4"), msgIndex1)
-      numberOfHits(msgIndex1) must be_==(3).retry(eventuallyRetries = 30)
-      probe must not(receive.like { case Status.Failure(_) => ok })
+        // after this valid one, the failed one above will be retried...
+        bulkInserter ! Insert(Json.obj("name" := "test5"), msgIndex)
+        numberOfHits(msgIndex) must be_==(4).retry(eventuallyRetries = 30)
+        probe must not(receive.like { case Status.Failure(_) => ok })
 
-      // after this valid one, the failed one above will be retried...
-      bulkInserter1 ! Insert(Json.obj("name" := "test5"), msgIndex1)
-      numberOfHits(msgIndex1) must be_==(4).retry(eventuallyRetries = 30)
-      probe must not(receive.like { case Status.Failure(_) => ok })
+        // after this valid one, the failed one above will be retried...
+        bulkInserter ! Insert(Json.obj("name" := "test6"), msgIndex)
+        numberOfHits(msgIndex) must be_==(5).retry(eventuallyRetries = 30)
+        probe must not(receive.like { case Status.Failure(_) => ok })
 
-      // after this valid one, the failed one above will be retried...
-      bulkInserter1 ! Insert(Json.obj("name" := "test6"), msgIndex1)
-      numberOfHits(msgIndex1) must be_==(5).retry(eventuallyRetries = 30)
-      probe must not(receive.like { case Status.Failure(_) => ok })
+        // after this valid one, finally the error will be sent back to the client
+        bulkInserter ! Insert(Json.obj("name" := "test7"), msgIndex)
+        numberOfHits(msgIndex) must be_==(6).retry(eventuallyRetries = 30)
+        probe must receive.like { case Status.Failure(_) => ok }
+      }
 
-      // after this valid one, finally the error will be sent back to the client
-      bulkInserter1 ! Insert(Json.obj("name" := "test7"), msgIndex1)
-      numberOfHits(msgIndex1) must be_==(6).retry(eventuallyRetries = 30)
-      probe must receive.like { case Status.Failure(_) => ok }
+      "when the buffer is automatically flushed on schedule" in {
+        val msgIndex = "test-index-6"
+        // maxTryCount is 3
+        val bulkInserter = testBulkInserter(maxBufferSize = 2, flushFreq = 500.millis)
 
-      // NOTICE: trying on a setting in which the retries are triggered by the flush frequency
-      val msgIndex2 = "test-index-6"
-      // maxTryCount is 3
-      val bulkInserter2 = testBulkInserter(maxBufferSize = 2, flushFreq = 500.millis)
+        // use a mapping that does not allow for extra fields other than the "name" one
+        esClient.execute(putMapping(msgIndex) rawSource """{"dynamic":"strict","properties":{"name":{"type":"text"}}}""") must
+          beAnInstanceOf[RequestSuccess[_]].awaitFor(5.seconds)
 
-      // use a mapping that does not allow for extra fields other than the "name" one
-      esClient.execute(putMapping(msgIndex2) rawSource """{"dynamic":"strict","properties":{"name":{"type":"text"}}}""") must
-        beAnInstanceOf[RequestSuccess[_]].awaitFor(5.seconds)
-
-      // insert an invalid document that will be retried
-      bulkInserter2.!(Insert(Json.obj("name" := "test3", "other" := "dynamic_field_value"), msgIndex2))(probe.ref)
-      numberOfHits(msgIndex2) must be_==(0).retry(eventuallyRetries = 30)
-      probe must receive.like { case Status.Failure(_) => ok }.eventually(30, 2.seconds)
+        // insert an invalid document that will be retried
+        val probe = TestProbe()
+        bulkInserter.!(Insert(Json.obj("name" := "test3", "other" := "dynamic_field_value"), msgIndex))(probe.ref)
+        numberOfHits(msgIndex) must be_==(0).retry(eventuallyRetries = 30)
+        probe must receive.like { case Status.Failure(_) => ok }.eventually(30, 2.seconds)
+      }
     }
   }
 

--- a/elasticsearch/src/test/scala/com/velocidi/apso/elasticsearch/ElasticsearchBulkInserterSpec.scala
+++ b/elasticsearch/src/test/scala/com/velocidi/apso/elasticsearch/ElasticsearchBulkInserterSpec.scala
@@ -157,7 +157,7 @@ class ElasticsearchBulkInserterSpec(implicit ee: ExecutionEnv) extends AkkaSpeci
       numberOfHits(msgIndex1) must be_==(6).retry(eventuallyRetries = 30)
       probe must receive.like { case Status.Failure(_) => ok }
 
-      // NOTICE: trying on a setting in which the retries are by the flush frequency
+      // NOTICE: trying on a setting in which the retries are triggered by the flush frequency
       val msgIndex2 = "test-index-6"
       // maxTryCount is 3
       val bulkInserter2 = testBulkInserter(maxBufferSize = 2, flushFreq = 500.millis)

--- a/elasticsearch/src/test/scala/com/velocidi/apso/elasticsearch/ElasticsearchBulkInserterSpec.scala
+++ b/elasticsearch/src/test/scala/com/velocidi/apso/elasticsearch/ElasticsearchBulkInserterSpec.scala
@@ -3,6 +3,7 @@ package com.velocidi.apso.elasticsearch
 import scala.concurrent.duration._
 
 import akka.actor._
+import akka.testkit.TestProbe
 import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.RequestSuccess
 import com.sksamuel.elastic4s.requests.searches._
@@ -10,6 +11,7 @@ import io.circe.Json
 import io.circe.syntax._
 import net.ruippeixotog.akka.testkit.specs2.mutable.AkkaSpecification
 import org.specs2.concurrent.ExecutionEnv
+import org.specs2.matcher.Matcher
 
 import com.velocidi.apso.elasticsearch.ElasticsearchBulkInserter.Insert
 import com.velocidi.apso.elasticsearch.config.Elasticsearch
@@ -45,8 +47,19 @@ class ElasticsearchBulkInserterSpec(implicit ee: ExecutionEnv) extends AkkaSpeci
   private def searchQuery(msgIndex: String): SearchRequest =
     search(msgIndex)
 
+  private def numberOfHits(index: String) = {
+    esClient.execute(searchQuery(index)).map(_.result.totalHits)
+  }
+
+  private implicit class ExtraMatchers[T](m: Matcher[T]) {
+    def retry(
+      awaitFor: FiniteDuration = 5.seconds,
+      eventuallyRetries: Int = 5,
+      eventuallyWait: FiniteDuration = 2.seconds) = m.awaitFor(awaitFor).eventually(eventuallyRetries, eventuallyWait)
+  }
+
   "An ElasticsearchBulkInserter" should {
-    Seq("test-index-1", "test-index-2", "test-index-3", "test-index-4").foreach(ensureIndexExists)
+    Seq("test-index-1", "test-index-2", "test-index-3", "test-index-4", "test-index-5", "test-index-6").foreach(ensureIndexExists)
 
     "collect events and send them in bulk to Elasticsearch after a buffer is filled" in {
       val msgIndex = "test-index-1"
@@ -54,10 +67,10 @@ class ElasticsearchBulkInserterSpec(implicit ee: ExecutionEnv) extends AkkaSpeci
       val bulkInserter = testBulkInserter(maxBufferSize = 5)
 
       for (i <- 1 to 3) bulkInserter ! Insert(Json.obj("id" := i), msgIndex)
-      esClient.execute(searchQuery(msgIndex)).map(_.result.totalHits) must not(be_==(3).awaitFor(5.seconds).eventually(5, 2.seconds))
+      numberOfHits(msgIndex) must not(be_==(3).retry())
 
       for (i <- 4 to 5) bulkInserter ! Insert(Json.obj("id" := i), msgIndex)
-      esClient.execute(searchQuery(msgIndex)).map(_.result.totalHits) must be_==(5).awaitFor(5.seconds).eventually(30, 2.seconds)
+      numberOfHits(msgIndex) must be_==(5).retry(eventuallyRetries = 30)
     }
 
     "collect events and send them in bulk to Elasticsearch after a periodic flush occurs" in {
@@ -68,9 +81,9 @@ class ElasticsearchBulkInserterSpec(implicit ee: ExecutionEnv) extends AkkaSpeci
       for (i <- 1 to 5) bulkInserter ! Insert(Json.obj("id" := i), msgIndex)
 
       Thread.sleep(5000)
-      esClient.execute(searchQuery(msgIndex)).map(_.result.totalHits) must be_==(0).awaitFor(5.seconds).eventually(10, 2.seconds)
+      numberOfHits(msgIndex) must be_==(0).retry(eventuallyRetries = 10)
       Thread.sleep(7500)
-      esClient.execute(searchQuery(msgIndex)).map(_.result.totalHits) must be_==(5).awaitFor(5.seconds).eventually(10, 2.seconds)
+      numberOfHits(msgIndex) must be_==(5).retry(eventuallyRetries = 10)
     }
 
     "correctly handle errors and retry document insertion errors" in {
@@ -85,22 +98,78 @@ class ElasticsearchBulkInserterSpec(implicit ee: ExecutionEnv) extends AkkaSpeci
       // insert a (valid) document
       bulkInserter ! Insert(Json.obj("name" := "test1"), msgIndex)
       bulkInserter ! Insert(Json.obj("name" := "test2"), msgIndex)
-      esClient.execute(searchQuery(msgIndex)).map(_.result.totalHits) must be_==(2).awaitFor(5.seconds).eventually(30, 2.seconds)
+      numberOfHits(msgIndex) must be_==(2).retry(eventuallyRetries = 30)
 
       // try to insert a (invalid) document; this one should stay on the buffer for retry later on...
       bulkInserter ! Insert(Json.obj("name" := "test3"), msgIndex)
       bulkInserter ! Insert(Json.obj("name" := "test4", "other" := "dynamic_field_value"), msgIndex)
-      esClient.execute(searchQuery(msgIndex)).map(_.result.totalHits) must not(be_==(4).awaitFor(5.seconds).eventually(5, 2.seconds))
-      esClient.execute(searchQuery(msgIndex)).map(_.result.totalHits) must be_==(3).awaitFor(5.seconds).eventually(5, 2.seconds)
+      numberOfHits(msgIndex) must not(be_==(4).retry())
+      numberOfHits(msgIndex) must be_==(3).retry()
 
       // now, change the mapping so that new fields are allowed...
       esClient.execute(putMapping(msgIndex) rawSource """{"dynamic":true,"properties":{"name":{"type":"text"}}}""") must
         beAnInstanceOf[RequestSuccess[_]].awaitFor(5.seconds)
       bulkInserter ! Insert(Json.obj("name" := "test5"), msgIndex)
-      esClient.execute(searchQuery(msgIndex)).map(_.result.totalHits) must
-        be_==(5).awaitFor(5.seconds).eventually(30, 2.seconds)
+      numberOfHits(msgIndex) must be_==(5).retry(eventuallyRetries = 30)
       esClient.execute(search(msgIndex) query matchQuery("other", "dynamic_field_value")).map(_.result.totalHits) must
-        be_==(1).awaitFor(5.seconds).eventually(30, 2.seconds)
+        be_==(1).retry(eventuallyRetries = 30)
+    }
+
+    "correctly send error back to client only when retries are exhausted" in {
+
+      // NOTICE: trying on a setting in which the retries are triggered by the buffer reaching its max capacity
+      val msgIndex1 = "test-index-5"
+      // maxTryCount is 3
+      val bulkInserter1 = testBulkInserter(maxBufferSize = 2, flushFreq = 1.day)
+
+      // use a mapping that does not allow for extra fields other than the "name" one
+      esClient.execute(putMapping(msgIndex1) rawSource """{"dynamic":"strict","properties":{"name":{"type":"text"}}}""") must
+        beAnInstanceOf[RequestSuccess[_]].awaitFor(5.seconds)
+
+      // insert valid documents
+      bulkInserter1 ! Insert(Json.obj("name" := "test1"), msgIndex1)
+      bulkInserter1 ! Insert(Json.obj("name" := "test2"), msgIndex1)
+      numberOfHits(msgIndex1) must be_==(2).retry(eventuallyRetries = 30)
+
+      // insert an invalid document that will be retried
+      val probe = TestProbe()
+      bulkInserter1.!(Insert(Json.obj("name" := "test3", "other" := "dynamic_field_value"), msgIndex1))(probe.ref)
+      numberOfHits(msgIndex1) must be_==(2).retry(eventuallyRetries = 30)
+      probe must not(receive.like { case Status.Failure(_) => ok })
+
+      // after this valid one, the failed one above will be retried...
+      bulkInserter1 ! Insert(Json.obj("name" := "test4"), msgIndex1)
+      numberOfHits(msgIndex1) must be_==(3).retry(eventuallyRetries = 30)
+      probe must not(receive.like { case Status.Failure(_) => ok })
+
+      // after this valid one, the failed one above will be retried...
+      bulkInserter1 ! Insert(Json.obj("name" := "test5"), msgIndex1)
+      numberOfHits(msgIndex1) must be_==(4).retry(eventuallyRetries = 30)
+      probe must not(receive.like { case Status.Failure(_) => ok })
+
+      // after this valid one, the failed one above will be retried...
+      bulkInserter1 ! Insert(Json.obj("name" := "test6"), msgIndex1)
+      numberOfHits(msgIndex1) must be_==(5).retry(eventuallyRetries = 30)
+      probe must not(receive.like { case Status.Failure(_) => ok })
+
+      // after this valid one, finally the error will be sent back to the client
+      bulkInserter1 ! Insert(Json.obj("name" := "test7"), msgIndex1)
+      numberOfHits(msgIndex1) must be_==(6).retry(eventuallyRetries = 30)
+      probe must receive.like { case Status.Failure(_) => ok }
+
+      // NOTICE: trying on a setting in which the retries are by the flush frequency
+      val msgIndex2 = "test-index-6"
+      // maxTryCount is 3
+      val bulkInserter2 = testBulkInserter(maxBufferSize = 2, flushFreq = 500.millis)
+
+      // use a mapping that does not allow for extra fields other than the "name" one
+      esClient.execute(putMapping(msgIndex2) rawSource """{"dynamic":"strict","properties":{"name":{"type":"text"}}}""") must
+        beAnInstanceOf[RequestSuccess[_]].awaitFor(5.seconds)
+
+      // insert an invalid document that will be retried
+      bulkInserter2.!(Insert(Json.obj("name" := "test3", "other" := "dynamic_field_value"), msgIndex2))(probe.ref)
+      numberOfHits(msgIndex2) must be_==(0).retry(eventuallyRetries = 30)
+      probe must receive.like { case Status.Failure(_) => ok }.eventually(30, 2.seconds)
     }
   }
 


### PR DESCRIPTION
Currently, `ElasticsearchBulkInserter` replies with a `Status.Failure` at each indexing retry, for the same message.

This changes that behavior so that `Status.Failure` is only sent when the retries are exhausted.