### PR TITLE
Correct Scala versions in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,12 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        scala: [2.12.10, 2.13.1]
-
-    env:
-      SCALA_VERSION: ${{ matrix.scala }}
+        scala: ['2.12', '2.13']
+        include:
+          - scala: '2.12'
+            scala-version: 2.12.12
+          - scala: '2.13'
+            scala-version: 2.13.4
 
     steps:
     - uses: actions/checkout@v2
@@ -40,6 +42,6 @@ jobs:
         path: ~/.sbt
         key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
     - name: Run tests
-      run: sbt -Dsbt.color=always ++$SCALA_VERSION test:compile test
+      run: sbt -Dsbt.color=always ++${{ matrix.scala-version }} test:compile test
     - name: Check mdoc for uncommitted changes
       run: sbt -Dsbt.color=always "docs/mdoc --check"


### PR DESCRIPTION
There was a mismatch between the Scala versions the project was being compiled with and the versions used in CI. Incidentally, this also tries to make the names of the checks more stable by not including the Scala version all the way to the patch.