### PR TITLE
Improve cache in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,31 +21,33 @@ jobs:
             scala-version: 2.13.6
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 1.8 and SBT
-      uses: olafurpg/setup-scala@v13
-      with:
-        java-version: adopt@1.8
-    - name: Cache Coursier
-      uses: actions/cache@v1
-      with:
-        path: ~/.cache/coursier
-        key: ${{ runner.os }}-coursier-${{ hashFiles('**/*.sbt') }}
-    - name: Cache SBT ivy cache
-      uses: actions/cache@v1
-      with:
-        path: ~/.ivy2/cache
-        key: ${{ runner.os }}-sbt-ivy-cache-${{ hashFiles('**/build.sbt') }}
-    - name: Cache SBT
-      uses: actions/cache@v1
-      with:
-        path: ~/.sbt
-        key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
-    - name: Compile and check format
-      run: >-
-        sbt ++${{ matrix.scala-version }} scalafmtSbt Test/compile &&
-        git diff --exit-code
-    - name: Run tests
-      run: sbt -Dsbt.color=always ++${{ matrix.scala-version }} test
-    - name: Check mdoc for uncommitted changes
-      run: sbt -Dsbt.color=always "docs/mdoc --check"
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up JDK and sbt
+        uses: olafurpg/setup-scala@v13
+        with:
+          java-version: adopt@1.8
+
+      - name: Cache sbt
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.sbt
+            ~/.ivy2/cache
+            ~/.coursier/cache/v1
+            ~/.cache/coursier/v1
+            ~/AppData/Local/Coursier/Cache/v1
+            ~/Library/Caches/Coursier/v1
+          key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+
+      - name: Compile and check format
+        run: >-
+          sbt ++${{ matrix.scala-version }} scalafmtSbt Test/compile &&
+          git diff --exit-code
+
+      - name: Run tests
+        run: sbt -Dsbt.color=always ++${{ matrix.scala-version }} test
+
+      - name: Check mdoc for uncommitted changes
+        run: sbt -Dsbt.color=always "docs/mdoc --check"


### PR DESCRIPTION
We don't need to have these many separated caching steps. This lists some folders unused by the OSs we currently run builds on, but I suppose it's OK to leave them there for reference (and in case we start building somewhere else).

Incidentally, this also reformats the YAML a bit.