### PR TITLE
Update `scalafmt` to 3.0.8 and apply style changes

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,8 +1,10 @@
-version = 2.7.5
+version = 3.0.6
 
+runner.dialect = scala213
 maxColumn = 120
 fileOverride {
   "glob:**/*.sbt" {
+    runner.dialect = sbt1
     align.preset = most
   }
   "glob:**/project/*.scala" {

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = 3.0.6
+version = 3.0.8
 
 runner.dialect = scala213
 maxColumn = 120

--- a/akka-http/src/main/scala/com/velocidi/apso/akka/http/ExtraMiscDirectives.scala
+++ b/akka-http/src/main/scala/com/velocidi/apso/akka/http/ExtraMiscDirectives.scala
@@ -19,11 +19,13 @@ trait ExtraMiscDirectives {
 
   /** Inserts a "Cache-Control" header, instructing the browser to cache the HTTP response for the supplied duration.
     * The header key "max-age" specifies the number of seconds during which the browser should cache the HTTP response.
-    * In case the supplied duration is less than 1 second, this directive defaults to the minimum duration allowed,
-    * 1 second.
+    * In case the supplied duration is less than 1 second, this directive defaults to the minimum duration allowed, 1
+    * second.
     *
-    * @param maxAgeDuration the duration for how long to cache the HTTP response
-    * @return a Directive that inserts a Cache-Control header
+    * @param maxAgeDuration
+    *   the duration for how long to cache the HTTP response
+    * @return
+    *   a Directive that inserts a Cache-Control header
     */
   def cacheControlMaxAge(maxAgeDuration: Option[FiniteDuration]): Directive0 = {
     maxAgeDuration match {

--- a/akka-http/src/main/scala/com/velocidi/apso/akka/http/ProxySupport.scala
+++ b/akka-http/src/main/scala/com/velocidi/apso/akka/http/ProxySupport.scala
@@ -24,9 +24,9 @@ import com.velocidi.apso.Logging
   * is continuously active and ready to route incoming requests.
   *
   * For one-off requests or requests to previously unknown hosts, this trait defines two routes:
-  * - `proxySingleTo` takes the original request and proxies it to the proxy URI;
-  * - `proxySingleToUnmatchedPath` copies only the unmatched path from the original URI, and adds it to the path of the
-  * proxy URI.
+  *   - `proxySingleTo` takes the original request and proxies it to the proxy URI;
+  *   - `proxySingleToUnmatchedPath` copies only the unmatched path from the original URI, and adds it to the path of
+  *     the proxy URI.
   *
   * In order for the client ip to be propagated in `X-Forwarded-For` headers, the
   * `akka.http.server.remote-address-attribute` config setting must be set to "on".
@@ -85,8 +85,10 @@ trait ProxySupport extends ClientIPDirectives {
 
   /** Proxies a single request to a destination URI.
     *
-    * @param uri the target URI
-    * @return a route that handles requests by proxying them to the given URI.
+    * @param uri
+    *   the target URI
+    * @return
+    *   a route that handles requests by proxying them to the given URI.
     */
   def proxySingleTo(uri: Uri): Route = proxy() { case (ip, ctx) =>
     ctx.request.withUri(uri).withHeaders(getHeaders(ip, ctx.request.headers.toList))
@@ -95,8 +97,10 @@ trait ProxySupport extends ClientIPDirectives {
   /** Proxies a single request to a destination base URI. The target URI is created by concatenating the base URI with
     * the unmatched path.
     *
-    * @param uri the target base URI
-    * @return a route that handles requests by proxying them to the given URI.
+    * @param uri
+    *   the target base URI
+    * @return
+    *   a route that handles requests by proxying them to the given URI.
     */
   def proxySingleToUnmatchedPath(uri: Uri): Route = proxy() { case (ip, ctx) =>
     ctx.request
@@ -104,24 +108,29 @@ trait ProxySupport extends ClientIPDirectives {
       .withHeaders(getHeaders(ip, ctx.request.headers.toList))
   }
 
-  /** Proxies a single request to a destination URI.
-    * The response in not streamed, but converted to a strict entity with a set timeout.
+  /** Proxies a single request to a destination URI. The response in not streamed, but converted to a strict entity with
+    * a set timeout.
     *
-    * @param uri the target URI
-    * @param timeout maximum time to wait for the full response.
-    * @return a route that handles requests by proxying them to the given URI.
+    * @param uri
+    *   the target URI
+    * @param timeout
+    *   maximum time to wait for the full response.
+    * @return
+    *   a route that handles requests by proxying them to the given URI.
     */
   def strictProxySingleTo(uri: Uri, timeout: FiniteDuration): Route = proxy(Some(timeout)) { case (ip, ctx) =>
     ctx.request.withUri(uri).withHeaders(getHeaders(ip, ctx.request.headers.toList))
   }
 
   /** Proxies a single request to a destination base URI. The target URI is created by concatenating the base URI with
-    * the unmatched path.
-    * The response in not streamed, but converted to a strict entity with a set timeout.
+    * the unmatched path. The response in not streamed, but converted to a strict entity with a set timeout.
     *
-    * @param uri the target base URI
-    * @param timeout maximum time to wait for the full response.
-    * @return a route that handles requests by proxying them to the given URI.
+    * @param uri
+    *   the target base URI
+    * @param timeout
+    *   maximum time to wait for the full response.
+    * @return
+    *   a route that handles requests by proxying them to the given URI.
     */
   def strictProxySingleToUnmatchedPath(uri: Uri, timeout: FiniteDuration): Route = proxy(Some(timeout)) {
     case (ip, ctx) =>
@@ -136,10 +145,14 @@ trait ProxySupport extends ClientIPDirectives {
   /** A representation of a reverse proxy for a remote host. This class internally materializes a flow that is
     * continuously active and ready to route incoming requests.
     *
-    * @param host the target host
-    * @param port the target port
-    * @param reqQueueSize the maximum size of the queue of pending backend requests
-    * @param strictTimeout maximum time to wait for the full response.
+    * @param host
+    *   the target host
+    * @param port
+    *   the target port
+    * @param reqQueueSize
+    *   the maximum size of the queue of pending backend requests
+    * @param strictTimeout
+    *   maximum time to wait for the full response.
     */
   class Proxy(
       host: String,
@@ -180,9 +193,12 @@ trait ProxySupport extends ClientIPDirectives {
 
     /** Sends a manually crafted request to a destination URI.
       *
-      * @param req the HTTP Request
-      * @param failOnDrop if the future should fail when the message is dropped, or complete with a 503
-      * @return the request result.
+      * @param req
+      *   the HTTP Request
+      * @param failOnDrop
+      *   if the future should fail when the message is dropped, or complete with a 503
+      * @return
+      *   the request result.
       */
     def sendRequest(req: HttpRequest, failOnDrop: Boolean): Future[RouteResult] = {
       val promise = Promise[RouteResult]()
@@ -199,8 +215,10 @@ trait ProxySupport extends ClientIPDirectives {
 
     /** Proxies a request to a destination URI.
       *
-      * @param uri the target URI
-      * @return a route that handles requests by proxying them to the given URI.
+      * @param uri
+      *   the target URI
+      * @return
+      *   a route that handles requests by proxying them to the given URI.
       */
     def proxyTo(uri: Uri): Route = {
       optionalRemoteAddress { ip => ctx =>

--- a/aws/src/main/scala/com/velocidi/apso/aws/ConfigCredentialsProvider.scala
+++ b/aws/src/main/scala/com/velocidi/apso/aws/ConfigCredentialsProvider.scala
@@ -4,9 +4,12 @@ import com.amazonaws.auth._
 import com.typesafe.config.{Config, ConfigFactory}
 
 /** AWS credentials provider that retrieves credentials from a typesafe configuration.
-  * @param config the typesafe configuration
-  * @param accessKeyPath the path in the configuration that contains the access key
-  * @param secretKeyPath the path in the configuration that contains the secret key
+  * @param config
+  *   the typesafe configuration
+  * @param accessKeyPath
+  *   the path in the configuration that contains the access key
+  * @param secretKeyPath
+  *   the path in the configuration that contains the secret key
   */
 case class ConfigCredentialsProvider(
     config: Config = ConfigFactory.load(),

--- a/aws/src/main/scala/com/velocidi/apso/aws/S3Bucket.scala
+++ b/aws/src/main/scala/com/velocidi/apso/aws/S3Bucket.scala
@@ -20,10 +20,11 @@ import com.velocidi.apso.{Logging, TryWith}
 /** A representation of an Amazon's S3 bucket. This class wraps an `AmazonS3Client` and provides a higher level
   * interface for pushing and pulling files to and from a bucket.
   *
-  * @param bucketName          the name of the bucket
-  * @param credentialsProvider optional AWS credentials provider to use (since AWSCredentials are not serializable).
-  *                            If the parameter is not supplied, they will be retrieved from the
-  *                            [[CredentialStore]].
+  * @param bucketName
+  *   the name of the bucket
+  * @param credentialsProvider
+  *   optional AWS credentials provider to use (since AWSCredentials are not serializable). If the parameter is not
+  *   supplied, they will be retrieved from the [[CredentialStore]].
   */
 class S3Bucket(
     val bucketName: String,
@@ -99,11 +100,13 @@ class S3Bucket(
 
   private[this] def sanitizeKey(key: String) = if (key.startsWith("./")) key.drop(2) else key
 
-  /** Returns size of the file in the location specified by `key` in the bucket. If the file doesn't
-    * exist the return value is 0.
+  /** Returns size of the file in the location specified by `key` in the bucket. If the file doesn't exist the return
+    * value is 0.
     *
-    * @param key the remote pathname for the file
-    * @return the size of the file in the location specified by `key` in the bucket if the exists, 0 otherwise.
+    * @param key
+    *   the remote pathname for the file
+    * @return
+    *   the size of the file in the location specified by `key` in the bucket if the exists, 0 otherwise.
     */
   def size(key: String): Long = retry {
     s3.getObjectMetadata(bucketName, key).getContentLength
@@ -111,8 +114,10 @@ class S3Bucket(
 
   /** Returns a list of objects in a bucket matching a given prefix.
     *
-    * @param prefix the prefix to match
-    * @return a list of objects in a bucket matching a given prefix.
+    * @param prefix
+    *   the prefix to match
+    * @return
+    *   a list of objects in a bucket matching a given prefix.
     */
   def getObjectsWithMatchingPrefix(prefix: String, includeDirectories: Boolean = false): Iterator[S3ObjectSummary] = {
     log.info(s"Finding files matching prefix '$prefix'...")
@@ -130,17 +135,22 @@ class S3Bucket(
 
   /** Returns a list of filenames and directories in a bucket matching a given prefix.
     *
-    * @param prefix the prefix to match
-    * @return a list of filenames in a bucket matching a given prefix.
+    * @param prefix
+    *   the prefix to match
+    * @return
+    *   a list of filenames in a bucket matching a given prefix.
     */
   def getFilesWithMatchingPrefix(prefix: String, includeDirectories: Boolean = false): Iterator[String] =
     getObjectsWithMatchingPrefix(prefix, includeDirectories).map(_.getKey)
 
   /** Pushes a given local `File` to the location specified by `key` in the bucket.
     *
-    * @param key the remote pathname for the file
-    * @param file the local `File` to push
-    * @return true if the push was successful, false otherwise.
+    * @param key
+    *   the remote pathname for the file
+    * @param file
+    *   the local `File` to push
+    * @return
+    *   true if the push was successful, false otherwise.
     */
   def push(key: String, file: File): Boolean = retry {
     log.info(s"Pushing file '${file.getPath}' to 's3://$bucketName/$key'")
@@ -151,10 +161,14 @@ class S3Bucket(
 
   /** Pushes a given `InputStream` to the location specified by `key` in the bucket.
     *
-    * @param key the remote pathname for the file
-    * @param inputStream the `InputStream` to push
-    * @param length the content lenght (setting this to `None` can impact performance
-    * @return true if the push was successful, false otherwise.
+    * @param key
+    *   the remote pathname for the file
+    * @param inputStream
+    *   the `InputStream` to push
+    * @param length
+    *   the content lenght (setting this to `None` can impact performance
+    * @return
+    *   true if the push was successful, false otherwise.
     */
   def push(key: String, inputStream: InputStream, length: Option[Long]): Boolean = retry {
     log.info(s"Pushing to 's3://$bucketName/$key'")
@@ -167,18 +181,22 @@ class S3Bucket(
 
   /** Deletes the file in the location specified by `key` in the bucket.
     *
-    * @param key the remote pathname for the file
-    * @return true if the deletion was successful, false otherwise.
+    * @param key
+    *   the remote pathname for the file
+    * @return
+    *   true if the deletion was successful, false otherwise.
     */
   def delete(key: String): Boolean = retry {
     s3.deleteObject(bucketName, sanitizeKey(key))
   }.isDefined
 
-  /** Checks if the file in the location specified by `key` in the bucket exists.
-    * It returns false if just checking for the bucket existence.
+  /** Checks if the file in the location specified by `key` in the bucket exists. It returns false if just checking for
+    * the bucket existence.
     *
-    * @param key the remote pathname for the file
-    * @return true if the file exists, false otherwise.
+    * @param key
+    *   the remote pathname for the file
+    * @return
+    *   true if the file exists, false otherwise.
     */
   def exists(key: String): Boolean = retry {
     key.nonEmpty && s3.doesObjectExist(bucketName, key)
@@ -186,8 +204,10 @@ class S3Bucket(
 
   /** Checks if the location specified by `key` is a directory.
     *
-    * @param key the remote pathname to the directory
-    * @return true if the path is a directory, false otherwise.
+    * @param key
+    *   the remote pathname to the directory
+    * @return
+    *   true if the path is a directory, false otherwise.
     */
   def isDirectory(key: String): Boolean = retry {
     s3.listObjects(
@@ -201,7 +221,8 @@ class S3Bucket(
 
   /** Checks whether the bucket exists
     *
-    * @return true if the bucket exists, false otherwise.
+    * @return
+    *   true if the bucket exists, false otherwise.
     */
   def bucketExists: Boolean = retry {
     s3.doesBucketExistV2(bucketName)
@@ -209,8 +230,10 @@ class S3Bucket(
 
   /** Sets an access control list on a given Amazon S3 object.
     *
-    * @param key the remote pathname for the file
-    * @param acl the `CannedAccessControlList` to be applied to the Amazon S3 object
+    * @param key
+    *   the remote pathname for the file
+    * @param acl
+    *   the `CannedAccessControlList` to be applied to the Amazon S3 object
     */
   def setAcl(key: String, acl: CannedAccessControlList) = {
     log.info(s"Setting 's3://$bucketName/$key' permissions to '$acl'")
@@ -219,8 +242,10 @@ class S3Bucket(
 
   /** Creates an empty directory at the given `key` location
     *
-    * @param key the remote pathname to the directory
-    * @return  true if the directory was created successfully, false otherwise.
+    * @param key
+    *   the remote pathname to the directory
+    * @return
+    *   true if the directory was created successfully, false otherwise.
     */
   def createDirectory(key: String): Boolean = retry {
     log.info(s"Creating directory in 's3://$bucketName/$key'")
@@ -232,11 +257,13 @@ class S3Bucket(
     s3.putObject(new PutObjectRequest(bucketName, sanitizeKey(key) + "/", emptyContent, metadata))
   }.isDefined
 
-  /** Backups a remote file with the given `key`. A backup consists in copying the supplied file to a backup folder under
-    * the same bucket and folder the file is currently in.
+  /** Backups a remote file with the given `key`. A backup consists in copying the supplied file to a backup folder
+    * under the same bucket and folder the file is currently in.
     *
-    * @param key the remote pathname to backup
-    * @return true if the backup was successful, false otherwise.
+    * @param key
+    *   the remote pathname to backup
+    * @return
+    *   true if the backup was successful, false otherwise.
     */
   def backup(key: String): Boolean = retry {
     val sanitizedKey = sanitizeKey(key)
@@ -254,9 +281,12 @@ class S3Bucket(
 
   /** Pulls a remote file with the given `key`, to the local storage in the pathname provided by `destination`.
     *
-    * @param key the remote pathname to pull from
-    * @param destination the local pathname to pull to
-    * @return true if the pull was successful, false otherwise
+    * @param key
+    *   the remote pathname to pull from
+    * @param destination
+    *   the local pathname to pull to
+    * @return
+    *   true if the pull was successful, false otherwise
     */
   def pull(key: String, destination: String): Boolean = retry {
     log.info(s"Pulling 's3://$bucketName/$key' to '$destination'")

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import spray.boilerplate.BoilerplatePlugin
 ThisBuild / organization := "com.velocidi"
 
 ThisBuild / crossScalaVersions := Seq("2.12.15", "2.13.6")
-ThisBuild / scalaVersion := "2.13.6"
+ThisBuild / scalaVersion       := "2.13.6"
 
 def module(project: Project, moduleName: String) =
   (project in file(moduleName))
@@ -143,8 +143,8 @@ lazy val commonSettings = Seq(
 // Enable the OrganizeImports Scalafix rule.
 ThisBuild / scalafixDependencies += "com.github.liancheng" %% "organize-imports" % "0.5.0"
 
-releaseCrossBuild := true
-releaseTagComment := s"Release ${(ThisBuild / version).value}"
+releaseCrossBuild    := true
+releaseTagComment    := s"Release ${(ThisBuild / version).value}"
 releaseCommitMessage := s"Set version to ${(ThisBuild / version).value}"
 
 releaseProcess := Seq[ReleaseStep](

--- a/caching/build.sbt
+++ b/caching/build.sbt
@@ -1,7 +1,7 @@
 import Dependencies._
 
 libraryDependencies ++= Seq(
-  "com.github.ben-manes.caffeine" % "caffeine"            % "2.7.0", // This wasn't updated due to incompatibility with scalacache-caffeine
+  "com.github.ben-manes.caffeine" % "caffeine"            % "2.7.0",    // This wasn't updated due to incompatibility with scalacache-caffeine
   "com.github.cb372"             %% "scalacache-caffeine" % "0.28.0",
   "com.github.cb372"             %% "scalacache-core"     % "0.28.0",
   "com.github.cb372"             %% "scalacache-guava"    % "0.28.0",

--- a/caching/src/main/scala/com/velocidi/apso/caching/Cache.scala
+++ b/caching/src/main/scala/com/velocidi/apso/caching/Cache.scala
@@ -32,8 +32,8 @@ trait Cache[V] { cache =>
 
   class Keyed(key: Any) {
 
-    /** Returns either the cached Future for the key or evaluates the given call-by-name argument
-      * which produces either a value instance of type `V` or a `Future[V]`.
+    /** Returns either the cached Future for the key or evaluates the given call-by-name argument which produces either
+      * a value instance of type `V` or a `Future[V]`.
       */
     def apply(magnet: => ValueMagnet[V])(implicit ec: ExecutionContext): Future[V] =
       cache.apply(
@@ -43,20 +43,20 @@ trait Cache[V] { cache =>
           catch { case NonFatal(e) => Future.failed(e) }
       )
 
-    /** Returns either the cached Future for the key or evaluates the given function which
-      * should lead to eventual completion of the promise.
+    /** Returns either the cached Future for the key or evaluates the given function which should lead to eventual
+      * completion of the promise.
       */
     def apply[U](f: Promise[V] => U)(implicit ec: ExecutionContext): Future[V] =
       cache.apply(key, () => { val p = Promise[V](); f(p); p.future })
   }
 
-  /** Returns either the cached Future for the given key or evaluates the given value generating
-    * function producing a `Future[V]`.
+  /** Returns either the cached Future for the given key or evaluates the given value generating function producing a
+    * `Future[V]`.
     */
   def apply(key: Any, genValue: () => Future[V])(implicit ec: ExecutionContext): Future[V]
 
-  /** Retrieves the future instance that is currently in the cache for the given key.
-    * Returns None if the key has no corresponding cache entry.
+  /** Retrieves the future instance that is currently in the cache for the given key. Returns None if the key has no
+    * corresponding cache entry.
     */
   def get(key: Any): Option[Future[V]]
 
@@ -68,24 +68,22 @@ trait Cache[V] { cache =>
     */
   def clear(): Unit
 
-  /** Returns the set of keys in the cache, in no particular order
-    * Should return in roughly constant time.
-    * Note that this number might not reflect the exact keys of active, unexpired
-    * cache entries, since expired entries are only evicted upon next access
-    * (or by being thrown out by a capacity constraint).
+  /** Returns the set of keys in the cache, in no particular order Should return in roughly constant time. Note that
+    * this number might not reflect the exact keys of active, unexpired cache entries, since expired entries are only
+    * evicted upon next access (or by being thrown out by a capacity constraint).
     */
   def keys: Set[Any]
 
-  /** Returns a snapshot view of the keys as an iterator, traversing the keys from the least likely
-    * to be retained to the most likely.  Note that this is not constant time.
-    * @param limit No more than limit keys will be returned
+  /** Returns a snapshot view of the keys as an iterator, traversing the keys from the least likely to be retained to
+    * the most likely. Note that this is not constant time.
+    * @param limit
+    *   No more than limit keys will be returned
     */
   def ascendingKeys(limit: Option[Int] = None): Iterator[Any]
 
-  /** Returns the upper bound for the number of currently cached entries.
-    * Note that this number might not reflect the exact number of active, unexpired
-    * cache entries, since expired entries are only evicted upon next access
-    * (or by being thrown out by a capacity constraint).
+  /** Returns the upper bound for the number of currently cached entries. Note that this number might not reflect the
+    * exact number of active, unexpired cache entries, since expired entries are only evicted upon next access (or by
+    * being thrown out by a capacity constraint).
     */
   def size: Int
 }

--- a/caching/src/main/scala/com/velocidi/apso/caching/LruCache.scala
+++ b/caching/src/main/scala/com/velocidi/apso/caching/LruCache.scala
@@ -26,7 +26,6 @@ import com.googlecode.concurrentlinkedhashmap.ConcurrentLinkedHashMap
 
 object LruCache {
 
-  // # source-quote-LruCache-apply
   /** Creates a new [[ExpiringLruCache]] or [[SimpleLruCache]] instance depending on whether a non-zero and finite
     * timeToLive and/or timeToIdle is set or not.
     */
@@ -36,7 +35,6 @@ object LruCache {
       timeToLive: Duration = Duration.Inf,
       timeToIdle: Duration = Duration.Inf
   ): Cache[V] = {
-    // #
     def check(dur: Duration, name: String) =
       require(
         dur != Duration.Zero,

--- a/caching/src/main/scala/com/velocidi/apso/caching/LruCache.scala
+++ b/caching/src/main/scala/com/velocidi/apso/caching/LruCache.scala
@@ -26,7 +26,7 @@ import com.googlecode.concurrentlinkedhashmap.ConcurrentLinkedHashMap
 
 object LruCache {
 
-  //# source-quote-LruCache-apply
+  // # source-quote-LruCache-apply
   /** Creates a new [[ExpiringLruCache]] or [[SimpleLruCache]] instance depending on whether a non-zero and finite
     * timeToLive and/or timeToIdle is set or not.
     */
@@ -36,7 +36,7 @@ object LruCache {
       timeToLive: Duration = Duration.Inf,
       timeToIdle: Duration = Duration.Inf
   ): Cache[V] = {
-    //#
+    // #
     def check(dur: Duration, name: String) =
       require(
         dur != Duration.Zero,

--- a/caching/src/main/scala/com/velocidi/apso/caching/LruCache.scala
+++ b/caching/src/main/scala/com/velocidi/apso/caching/LruCache.scala
@@ -27,9 +27,8 @@ import com.googlecode.concurrentlinkedhashmap.ConcurrentLinkedHashMap
 object LruCache {
 
   //# source-quote-LruCache-apply
-  /** Creates a new [[ExpiringLruCache]] or
-    * [[SimpleLruCache]] instance depending on whether
-    * a non-zero and finite timeToLive and/or timeToIdle is set or not.
+  /** Creates a new [[ExpiringLruCache]] or [[SimpleLruCache]] instance depending on whether a non-zero and finite
+    * timeToLive and/or timeToIdle is set or not.
     */
   def apply[V](
       maxCapacity: Int = 500,
@@ -55,10 +54,9 @@ object LruCache {
   }
 }
 
-/** A thread-safe implementation of [[Cache]].
-  * The cache has a defined maximum number of entries it can store. After the maximum capacity is reached new
-  * entries cause old ones to be evicted in a last-recently-used manner, i.e. the entries that haven't been accessed for
-  * the longest time are evicted first.
+/** A thread-safe implementation of [[Cache]]. The cache has a defined maximum number of entries it can store. After the
+  * maximum capacity is reached new entries cause old ones to be evicted in a last-recently-used manner, i.e. the
+  * entries that haven't been accessed for the longest time are evicted first.
   */
 final class SimpleLruCache[V](val maxCapacity: Int, val initialCapacity: Int) extends Cache[V] {
   require(maxCapacity >= 0, "maxCapacity must not be negative")
@@ -102,19 +100,19 @@ final class SimpleLruCache[V](val maxCapacity: Int, val initialCapacity: Int) ex
   def size = store.size
 }
 
-/** A thread-safe implementation of [[Cache]].
-  * The cache has a defined maximum number of entries is can store. After the maximum capacity has been reached new
-  * entries cause old ones to be evicted in a last-recently-used manner, i.e. the entries that haven't been accessed for
-  * the longest time are evicted first.
-  * In addition this implementation optionally supports time-to-live as well as time-to-idle expiration.
-  * The former provides an upper limit to the time period an entry is allowed to remain in the cache while the latter
-  * limits the maximum time an entry is kept without having been accessed. If both values are non-zero the time-to-live
-  * has to be strictly greater than the time-to-idle.
+/** A thread-safe implementation of [[Cache]]. The cache has a defined maximum number of entries is can store. After the
+  * maximum capacity has been reached new entries cause old ones to be evicted in a last-recently-used manner, i.e. the
+  * entries that haven't been accessed for the longest time are evicted first. In addition this implementation
+  * optionally supports time-to-live as well as time-to-idle expiration. The former provides an upper limit to the time
+  * period an entry is allowed to remain in the cache while the latter limits the maximum time an entry is kept without
+  * having been accessed. If both values are non-zero the time-to-live has to be strictly greater than the time-to-idle.
   * Note that expired entries are only evicted upon next access (or by being thrown out by the capacity constraint), so
   * they might prevent gargabe collection of their values for longer than expected.
   *
-  * @param timeToLive the time-to-live in millis, zero for disabling ttl-expiration
-  * @param timeToIdle the time-to-idle in millis, zero for disabling tti-expiration
+  * @param timeToLive
+  *   the time-to-live in millis, zero for disabling ttl-expiration
+  * @param timeToIdle
+  *   the time-to-idle in millis, zero for disabling tti-expiration
   */
 final class ExpiringLruCache[V](maxCapacity: Long, initialCapacity: Int, timeToLive: Duration, timeToIdle: Duration)
     extends Cache[V] {

--- a/caching/src/main/scala/com/velocidi/apso/caching/ModeImpl.scala
+++ b/caching/src/main/scala/com/velocidi/apso/caching/ModeImpl.scala
@@ -5,7 +5,8 @@ import scala.concurrent.{ExecutionContext, Future}
 import scalacache.{Id, Mode}
 
 /** Represents a container mode for a cached value.
-  * @tparam F the container type, e.g., Future, Try.
+  * @tparam F
+  *   the container type, e.g., Future, Try.
   */
 trait ModeImpl[F[_]] {
   def mode: Mode[F]

--- a/circe/src/main/scala/com/velocidi/apso/circe/ExtraJsonProtocol.scala
+++ b/circe/src/main/scala/com/velocidi/apso/circe/ExtraJsonProtocol.scala
@@ -82,18 +82,24 @@ trait ExtraMiscJsonProtocol {
 
   /** Encodes a map as an array of key-value objects.
     *
-    * @tparam K the type of the keys of the map
-    * @tparam V the types of the value of the map
-    * @return an instance of `Encoder` for the map
+    * @tparam K
+    *   the type of the keys of the map
+    * @tparam V
+    *   the types of the value of the map
+    * @return
+    *   an instance of `Encoder` for the map
     */
   def mapJsonArrayEncoder[K: Encoder, V: Encoder]: Encoder[Map[K, V]] =
     Encoder[List[MapEntry[K, V]]].contramap(_.toList.map { case (k, v) => MapEntry(k, v) })
 
   /** Decodes a map from an array of key-value objects.
     *
-    * @tparam K the type of the keys of the map
-    * @tparam V the types of the value of the map
-    * @return an instance of `Decoder` for the map
+    * @tparam K
+    *   the type of the keys of the map
+    * @tparam V
+    *   the types of the value of the map
+    * @return
+    *   an instance of `Decoder` for the map
     */
   def mapJsonArrayDecoder[K: Decoder, V: Decoder]: Decoder[Map[K, V]] =
     Decoder[List[MapEntry[K, V]]].map(_.flatMap(me => Some(me.key, me.value)).toMap)

--- a/circe/src/main/scala/com/velocidi/apso/circe/Implicits.scala
+++ b/circe/src/main/scala/com/velocidi/apso/circe/Implicits.scala
@@ -18,8 +18,10 @@ object Implicits {
       *
       * Eg. {"a":1,"b":{"c":2},"d":null}.flattenedKeySet(".") = Set("a" -> JNumber(1),"b.c" -> JNumber(2), "d" -> JNull)
       *
-      * @param separator character separator to use
-      * @return flattened key set
+      * @param separator
+      *   character separator to use
+      * @return
+      *   flattened key set
       */
     def flattenedKeyValueSet(separator: String = "."): Set[(String, Json)] = {
       json.asObject match {
@@ -38,9 +40,12 @@ object Implicits {
       *
       * Eg. {"a":1,"b":{"c":2},"d":null}.flattenedKeySet(".", ignoreNull = true) = Set("a","b.c")
       *
-      * @param separator character separator to use
-      * @param ignoreNull if set, fields with a null value are ignored
-      * @return flattened key set
+      * @param separator
+      *   character separator to use
+      * @param ignoreNull
+      *   if set, fields with a null value are ignored
+      * @return
+      *   flattened key set
       */
     def flattenedKeySet(separator: String = ".", ignoreNull: Boolean = true): Set[String] =
       flattenedKeyValueSet(separator)
@@ -53,10 +58,14 @@ object Implicits {
       *
       * Eg. {"a":{"b":1}}.getField("a.b") = 1
       *
-      * @param fieldPath path from the root of the json object to the field
-      * @param separator character that separates each element of the path
-      * @tparam A type of the field value
-      * @return an option with the field value
+      * @param fieldPath
+      *   path from the root of the json object to the field
+      * @param separator
+      *   character that separates each element of the path
+      * @tparam A
+      *   type of the field value
+      * @return
+      *   an option with the field value
       */
     def getField[A: Decoder](fieldPath: String, separator: Char = '.'): Option[A] =
       getCursor(fieldPath, separator).as[A].fold(_ => None, Some(_))
@@ -65,9 +74,12 @@ object Implicits {
       *
       * Eg. {"a":1,"b":{"c":2},"d":null}.deleteField("b.c") = {"a":1,"b":{},"d":null}
       *
-      * @param fieldPath path from the root of the json object to the field
-      * @param separator character that separates each element of the path
-      * @return the json without the deleted value
+      * @param fieldPath
+      *   path from the root of the json object to the field
+      * @param separator
+      *   character that separates each element of the path
+      * @return
+      *   the json without the deleted value
       */
     def deleteField(fieldPath: String, separator: Char = '.'): Json = {
       require(fieldPath.nonEmpty, "The field path must have value.")
@@ -77,9 +89,12 @@ object Implicits {
 
     /** Returns a cursor on the field on the end of the tree, separated by the separator character.
       *
-      * @param fieldPath path from the root of the json object to the field
-      * @param separator character that separates each element of the path
-      * @return cursor to the field value
+      * @param fieldPath
+      *   path from the root of the json object to the field
+      * @param separator
+      *   character that separates each element of the path
+      * @return
+      *   cursor to the field value
       */
     def getCursor(fieldPath: String, separator: Char): ACursor =
       fieldPath
@@ -89,11 +104,14 @@ object Implicits {
         }
   }
 
-  /** Creates a Json from a sequence of pairs of dot-separated (or other separator) paths with the corresponding
-    * leaf values (eg. `List(("root.leaf1", "leafVal1"), ("root.leaf2", "leafVal2"))`
-    * @param paths the sequence of dot-separated (or other separator) paths
-    * @param separatorRegex regex to use to separate fields
-    * @return the resulting Json object
+  /** Creates a Json from a sequence of pairs of dot-separated (or other separator) paths with the corresponding leaf
+    * values (eg. `List(("root.leaf1", "leafVal1"), ("root.leaf2", "leafVal2"))`
+    * @param paths
+    *   the sequence of dot-separated (or other separator) paths
+    * @param separatorRegex
+    *   regex to use to separate fields
+    * @return
+    *   the resulting Json object
     */
   def fromFullPaths(paths: Seq[(String, Json)], separatorRegex: String = "\\."): Json = {
     def createJson(keys: Seq[String], value: Json): Json = {
@@ -113,15 +131,19 @@ object Implicits {
   final implicit class ApsoJsonEncoder[A](val encoder: Encoder[A]) extends AnyVal {
 
     /** Returns an encoder that removes the json fields that are null, applied on the root of the json.
-      * @return encoder that filters null fields.
+      * @return
+      *   encoder that filters null fields.
       */
     def withoutNulls: Encoder[A] = encoder.mapJson(_.mapObject(_.filter(!_._2.isNull)))
 
     /** Returns an encoder that adds an element to the root of the json object.
       *
-      * @param key the key of the element
-      * @param value the value of the element
-      * @return encoder that adds element to the json
+      * @param key
+      *   the key of the element
+      * @param value
+      *   the value of the element
+      * @return
+      *   encoder that adds element to the json
       */
     def withExtraField(key: String, value: Json): Encoder[A] = encoder.mapJson(_.mapObject(_.add(key, value)))
   }

--- a/circe/src/main/scala/com/velocidi/apso/circe/JsonConvert.scala
+++ b/circe/src/main/scala/com/velocidi/apso/circe/JsonConvert.scala
@@ -11,8 +11,10 @@ import io.circe.syntax._
 object JsonConvert {
 
   /** Converts an object to a [[io.circe.Json]] value using the most suitable data types.
-    * @param obj the object to convert
-    * @return the given object converted to a [[io.circe.Json]] value.
+    * @param obj
+    *   the object to convert
+    * @return
+    *   the given object converted to a [[io.circe.Json]] value.
     */
   def toJson(obj: Any): Json = obj match {
     case null           => Json.Null

--- a/circe/src/main/scala/com/velocidi/apso/circe/syntax/package.scala
+++ b/circe/src/main/scala/com/velocidi/apso/circe/syntax/package.scala
@@ -7,11 +7,12 @@ import io.circe.Decoder
 package object syntax {
   implicit class DecoderExtras[A](val decoder: Decoder[A]) extends AnyVal {
 
-    /** Performs similarly to `emapTry` but in case of failure it exclusively uses the Throwable's message
-      * to create the DecodingFailure message whereas `emapTry` would use the message+stacktrace.
-      * Related issue: https://github.com/circe/circe/issues/306
+    /** Performs similarly to `emapTry` but in case of failure it exclusively uses the Throwable's message to create the
+      * DecodingFailure message whereas `emapTry` would use the message+stacktrace. Related issue:
+      * https://github.com/circe/circe/issues/306
       *
-      * @param f a function returning a Try of value
+      * @param f
+      *   a function returning a Try of value
       */
     def emapPrettyTry[B](f: A => Try[B]): Decoder[B] =
       decoder.emap(f(_).toEither.left.map(_.getMessage))

--- a/collections/src/main/scala/com/velocidi/apso/collection/DeboxMap.scala
+++ b/collections/src/main/scala/com/velocidi/apso/collection/DeboxMap.scala
@@ -1,24 +1,20 @@
-/** This file contains an adaptation of debox/Map by Erik Osheim (https://github.com/non/debox). Debox is MIT-licensed and has the following copyright notice:
+/** This file contains an adaptation of debox/Map by Erik Osheim (https://github.com/non/debox). Debox is MIT-licensed
+  * and has the following copyright notice:
   *
   * Copyright (c) 2012-2015 Erik Osheim
   *
-  * Permission is hereby granted, free of charge, to any person obtaining a copy of
-  * this software and associated documentation files (the "Software"), to deal in
-  * the Software without restriction, including without limitation the rights to
-  * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-  * of the Software, and to permit persons to whom the Software is furnished to do
-  * so, subject to the following conditions:
+  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+  * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+  * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  * permit persons to whom the Software is furnished to do so, subject to the following conditions:
   *
-  * The above copyright notice and this permission notice shall be included in all
-  * copies or substantial portions of the Software.
+  * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+  * Software.
   *
-  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-  * SOFTWARE.
+  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+  * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+  * OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
   */
 
 package com.velocidi.apso.collection
@@ -27,21 +23,23 @@ import scala.annotation.tailrec
 import scala.reflect.ClassTag
 import scala.{specialized => spec}
 
-/** Exception thrown when a `DeboxMap` factory is called with a different number
-  * of keys and values.
-  * @param k the number of keys
-  * @param v the number of values
+/** Exception thrown when a `DeboxMap` factory is called with a different number of keys and values.
+  * @param k
+  *   the number of keys
+  * @param v
+  *   the number of values
   */
 class InvalidSizes(k: Int, v: Int) extends Exception("%s, %s" format (k, v))
 
-/** Exception thrown when a `DeboxMap` factory is called requiring an invalid
-  * preallocated size.
-  * @param n the requested size
+/** Exception thrown when a `DeboxMap` factory is called requiring an invalid preallocated size.
+  * @param n
+  *   the requested size
   */
 class MapOverflow(n: Int) extends Exception("size %s exceeds max" format n)
 
 /** Exception thrown when trying to access a non-existent key in a `DeboxMap`.
-  * @param k the non-existent key
+  * @param k
+  *   the non-existent key
   */
 class NotFound(k: String) extends Exception("key %s was not found" format k)
 
@@ -50,21 +48,27 @@ class NotFound(k: String) extends Exception("key %s was not found" format k)
 object DeboxMap {
 
   /** Creates an empty `DeboxMap`.
-    * @tparam A the type of the keys of the new map
-    * @tparam B the type of the values of the new map
-    * @return a new, empty `DeboxMap`.
+    * @tparam A
+    *   the type of the keys of the new map
+    * @tparam B
+    *   the type of the values of the new map
+    * @return
+    *   a new, empty `DeboxMap`.
     */
   def empty[@spec(Int, Long, Double, AnyRef) A: ClassTag, @spec(Int, Long, Double, AnyRef) B: ClassTag] =
     new DeboxMap(new Array[A](8), new Array[B](8), new Array[Byte](8), 0, 0)
 
-  /** Creates a DeboxMap preallocated to a particular size. Note that the
-    * internal representation may allocate more space than requested to satisfy
-    * the requirements of internal alignment. DeboxMap uses arrays whose lengths
-    * are powers of two.
-    * @param n the minimum number of elements to allocate space for
-    * @tparam A the type of the keys of the new map
-    * @tparam B the type of the values of the new map
-    * @return a new `DeboxMap` with the required preallocated space.
+  /** Creates a DeboxMap preallocated to a particular size. Note that the internal representation may allocate more
+    * space than requested to satisfy the requirements of internal alignment. DeboxMap uses arrays whose lengths are
+    * powers of two.
+    * @param n
+    *   the minimum number of elements to allocate space for
+    * @tparam A
+    *   the type of the keys of the new map
+    * @tparam B
+    *   the type of the values of the new map
+    * @return
+    *   a new `DeboxMap` with the required preallocated space.
     */
   def ofDim[@spec(Int, Long, Double, AnyRef) A: ClassTag, @spec(Int, Long, Double, AnyRef) B: ClassTag](n: Int) = {
     val sz = nextPowerOfTwo(n)
@@ -73,18 +77,26 @@ object DeboxMap {
   }
 
   /** Creates an empty DeboxMap.
-    * @tparam A the type of the keys of the new map
-    * @tparam B the type of the values of the new map
-    * @return a new, empty `DeboxMap`.
+    * @tparam A
+    *   the type of the keys of the new map
+    * @tparam B
+    *   the type of the values of the new map
+    * @return
+    *   a new, empty `DeboxMap`.
     */
   def apply[@spec(Int, Long, Double, AnyRef) A: ClassTag, @spec(Int, Long, Double, AnyRef) B: ClassTag]() = empty[A, B]
 
   /** Creates a map from an array of keys and another array of values.
-    * @param ks the array of keys to add to the map
-    * @param vs the array of corresponding values to add to the map
-    * @tparam A the type of the keys of the new map
-    * @tparam B the type of the values of the new map
-    * @return a new `DeboxMap` with the given elements
+    * @param ks
+    *   the array of keys to add to the map
+    * @param vs
+    *   the array of corresponding values to add to the map
+    * @tparam A
+    *   the type of the keys of the new map
+    * @tparam B
+    *   the type of the values of the new map
+    * @return
+    *   a new `DeboxMap` with the given elements
     */
   def apply[@spec(Int, Long, Double, AnyRef) A: ClassTag, @spec(Int, Long, Double, AnyRef) B: ClassTag](
       ks: Array[A],
@@ -109,10 +121,11 @@ object DeboxMap {
   }
 }
 
-/** An hash map optimized for performance, not incurring in boxing while storing
-  * primitive values.
-  * @tparam A the type of the keys
-  * @tparam B the type of the values
+/** An hash map optimized for performance, not incurring in boxing while storing primitive values.
+  * @tparam A
+  *   the type of the keys
+  * @tparam B
+  *   the type of the values
   */
 final class DeboxMap[
     @spec(Int, Long, Double, AnyRef) A: ClassTag,
@@ -140,14 +153,16 @@ final class DeboxMap[
   var limit = (keys.length * 0.65).toInt // point at which we should resize
 
   /** Returns the number of entries in this map.
-    * @return the number of entries in this map.
+    * @return
+    *   the number of entries in this map.
     */
   final def length: Int = len
 
-  /** Updates the value of a key. If the key does not exist, it is added to the
-    * map.
-    * @param key the key to update
-    * @param value the value to assign to the given key
+  /** Updates the value of a key. If the key does not exist, it is added to the map.
+    * @param key
+    *   the key to update
+    * @param value
+    *   the value to assign to the given key
     */
   final def update(key: A, value: B): Unit = {
     @inline @tailrec
@@ -174,9 +189,9 @@ final class DeboxMap[
     loop(i, i, -1)
   }
 
-  /** Removes a key from this map. If the key does not exist, this method does
-    * nothing.
-    * @param key the key to remove
+  /** Removes a key from this map. If the key does not exist, this method does nothing.
+    * @param key
+    *   the key to remove
     */
   final def remove(key: A): Unit = {
     @inline @tailrec def loop(i: Int, perturbation: Int): Unit = {
@@ -194,14 +209,17 @@ final class DeboxMap[
   }
 
   /** Returns a copy of this map.
-    * @return a copy of this map.
+    * @return
+    *   a copy of this map.
     */
   final def copy: DeboxMap[A, B] =
     new DeboxMap(keys.clone(), vals.clone(), buckets.clone(), len, used)
 
   /** Tests if this map contains a given key.
-    * @param key the key to test for membership
-    * @return `true` if the map contains the given key, `false` otherwise.
+    * @param key
+    *   the key to test for membership
+    * @return
+    *   `true` if the map contains the given key, `false` otherwise.
     */
   final def contains(key: A): Boolean = {
     @inline
@@ -220,10 +238,11 @@ final class DeboxMap[
     loop(i, i)
   }
 
-  /** Returns the value associated with a key. If the key does not exist, a
-    * `NotFound` exception is thrown.
-    * @param key the key to lookup
-    * @return the value associated with the given key.
+  /** Returns the value associated with a key. If the key does not exist, a `NotFound` exception is thrown.
+    * @param key
+    *   the key to lookup
+    * @return
+    *   the value associated with the given key.
     */
   final def apply(key: A): B = {
     @inline
@@ -242,11 +261,11 @@ final class DeboxMap[
     loop(i, i)
   }
 
-  /** Returns the value associated with a key or `None` if the key does not
-    * exist.
-    * @param key the key to lookup
-    * @return the value associated with the given key wrapped in a `Some` if this
-    *         map contains the key, `None` otherwise.
+  /** Returns the value associated with a key or `None` if the key does not exist.
+    * @param key
+    *   the key to lookup
+    * @return
+    *   the value associated with the given key wrapped in a `Some` if this map contains the key, `None` otherwise.
     */
   final def get(key: A): Option[B] = {
     @inline
@@ -265,13 +284,13 @@ final class DeboxMap[
     loop(i, i)
   }
 
-  /** Returns the value associated with a key or a default value if the key does
-    * not exist.
-    * @param key the key to lookup
-    * @param default the value to return if this map does not contain the given
-    *        key
-    * @return the value associated with the given key if this map contains the
-    *         key, `default` otherwise.
+  /** Returns the value associated with a key or a default value if the key does not exist.
+    * @param key
+    *   the key to lookup
+    * @param default
+    *   the value to return if this map does not contain the given key
+    * @return
+    *   the value associated with the given key if this map contains the key, `default` otherwise.
     */
   final def getOrElse(key: A, default: => B): B = {
     @inline
@@ -290,13 +309,14 @@ final class DeboxMap[
     loop(i, i)
   }
 
-  /** If given key is already in this map, returns associated value. Otherwise,
-    * stores the given default value with key in map and returns
-    * that value.
-    * @param key the key to lookup
-    * @param default the value to associate with key, if key is previously unbound.
-    * @return the value associated with the given key if this map contains the
-    *         key, `default` otherwise.
+  /** If given key is already in this map, returns associated value. Otherwise, stores the given default value with key
+    * in map and returns that value.
+    * @param key
+    *   the key to lookup
+    * @param default
+    *   the value to associate with key, if key is previously unbound.
+    * @return
+    *   the value associated with the given key if this map contains the key, `default` otherwise.
     */
   final def getOrElseUpdate(key: A, default: => B): B = {
     @inline
@@ -326,8 +346,8 @@ final class DeboxMap[
   }
 
   /** Applies a function `f` to all entries of this map.
-    * @param f the function that is applied for its side-effect to every element.
-    *        The result of function `f` is discarded.
+    * @param f
+    *   the function that is applied for its side-effect to every element. The result of function `f` is discarded.
     */
   final def foreach(f: (A, B) => Unit) = {
     @inline
@@ -345,10 +365,13 @@ final class DeboxMap[
   }
 
   /** Builds a new list by applying a function to all entries of this map.
-    * @param f the function to apply to each element
-    * @tparam C the type of the elements in the returned list
-    * @return a new list resulting from applying the given function `f` to each
-    *         element of this map and collecting the results.
+    * @param f
+    *   the function to apply to each element
+    * @tparam C
+    *   the type of the elements in the returned list
+    * @return
+    *   a new list resulting from applying the given function `f` to each element of this map and collecting the
+    *   results.
     */
   final def map[C](f: (A, B) => C): List[C] = {
     @inline

--- a/collections/src/main/scala/com/velocidi/apso/collection/Trie.scala
+++ b/collections/src/main/scala/com/velocidi/apso/collection/Trie.scala
@@ -2,11 +2,15 @@ package com.velocidi.apso.collection
 
 /** An immutable implementation of a Trie (https://en.wikipedia.org/wiki/Trie).
   *
-  * @param value the optional value of this node
-  * @param nodes the descendants of this node
+  * @param value
+  *   the optional value of this node
+  * @param nodes
+  *   the descendants of this node
   *
-  * @tparam K the type param of keys in the nodes
-  * @tparam V the type param of values stored in the trie
+  * @tparam K
+  *   the type param of keys in the nodes
+  * @tparam V
+  *   the type param of values stored in the trie
   */
 case class Trie[K, V](value: Option[V] = None, nodes: Map[K, Trie[K, V]] = Map[K, Trie[K, V]]()) {
 

--- a/collections/src/main/scala/com/velocidi/apso/collection/TypedMap.scala
+++ b/collections/src/main/scala/com/velocidi/apso/collection/TypedMap.scala
@@ -2,8 +2,7 @@ package com.velocidi.apso.collection
 
 import scala.reflect.ClassTag
 
-/** Typed map that associates types with values.
-  * Based on http://stackoverflow.com/a/7337610/4243494
+/** Typed map that associates types with values. Based on http://stackoverflow.com/a/7337610/4243494
   */
 class TypedMap[T] private (val inner: Map[ClassTag[_], T]) {
   def +[U >: T, L <: U](t: Typed[L]) = new TypedMap[U](inner.+[U](t.toPair))

--- a/collections/src/main/scala/com/velocidi/apso/collection/package.scala
+++ b/collections/src/main/scala/com/velocidi/apso/collection/package.scala
@@ -1,6 +1,5 @@
 package com.velocidi.apso
 
-/** Provides new types of collections and utility classes and methods for
-  * handling and extending existing ones.
+/** Provides new types of collections and utility classes and methods for handling and extending existing ones.
   */
 package object collection

--- a/collections/src/main/scala/com/velocidi/apso/iterator/CircularIterator.scala
+++ b/collections/src/main/scala/com/velocidi/apso/iterator/CircularIterator.scala
@@ -1,9 +1,10 @@
 package com.velocidi.apso.iterator
 
-/** A wrapper around an iterator that iterates over its elements in a circular
-  * way.
-  * @param it the inner iterator
-  * @tparam A the type of the elements to iterate over
+/** A wrapper around an iterator that iterates over its elements in a circular way.
+  * @param it
+  *   the inner iterator
+  * @tparam A
+  *   the type of the elements to iterate over
   */
 class CircularIterator[A](it: => Iterator[A]) extends Iterator[A] {
   var currentIt = it

--- a/collections/src/main/scala/com/velocidi/apso/iterator/CompositeIterator.scala
+++ b/collections/src/main/scala/com/velocidi/apso/iterator/CompositeIterator.scala
@@ -2,13 +2,13 @@ package com.velocidi.apso.iterator
 
 import scala.collection.{AbstractIterator, BufferedIterator, Iterator}
 
-/** An iterator that wraps a list of other iterators and iterates over its
-  * elements sequentially. It handles compositions of a large number of iterators
-  * in a more efficient way than simply concatenating them, avoiding stack
-  * overflows in particular. It supports appending of new iterators while keeping
-  * its efficiency.
-  * @param iterators the list of iterators to compose
-  * @tparam A the type of the elements to iterate over
+/** An iterator that wraps a list of other iterators and iterates over its elements sequentially. It handles
+  * compositions of a large number of iterators in a more efficient way than simply concatenating them, avoiding stack
+  * overflows in particular. It supports appending of new iterators while keeping its efficiency.
+  * @param iterators
+  *   the list of iterators to compose
+  * @tparam A
+  *   the type of the elements to iterate over
   */
 @deprecated("The stack overflow caused by Iterator.++ should be fixed in recent Scala versions.", "0.15.0")
 class CompositeIterator[A](

--- a/collections/src/main/scala/com/velocidi/apso/iterator/MergedBufferedIterator.scala
+++ b/collections/src/main/scala/com/velocidi/apso/iterator/MergedBufferedIterator.scala
@@ -28,11 +28,14 @@ case class MergedBufferedIterator[T](iterators: List[BufferedIterator[T]])(impli
 
   def hasNext: Boolean = nonEmptyIterators.nonEmpty
 
-  /** Lazily merges this buffered iterator with another buffered iterator assuming that both collections
-    * are already sorted.
-    * @param thatIt the iterator  to merge with this one
-    * @tparam U element type of the resulting collection
-    * @return the merged iterators
+  /** Lazily merges this buffered iterator with another buffered iterator assuming that both collections are already
+    * sorted.
+    * @param thatIt
+    *   the iterator to merge with this one
+    * @tparam U
+    *   element type of the resulting collection
+    * @return
+    *   the merged iterators
     */
   def mergeSorted[U >: T](thatIt: BufferedIterator[U])(implicit ord: Ordering[U]): BufferedIterator[U] =
     thatIt match {

--- a/collections/src/main/scala/com/velocidi/apso/iterator/package.scala
+++ b/collections/src/main/scala/com/velocidi/apso/iterator/package.scala
@@ -1,6 +1,5 @@
 package com.velocidi.apso
 
-/** Provides new types of iterators and utility classes and methods for handling
-  * and extending existing ones.
+/** Provides new types of iterators and utility classes and methods for handling and extending existing ones.
   */
 package object iterator

--- a/core/src/main/scala/com/velocidi/apso/Geo.scala
+++ b/core/src/main/scala/com/velocidi/apso/Geo.scala
@@ -12,19 +12,24 @@ object Geo {
 
   private[this] val EARTH_RADIUS = 6371.009 // kilometers
 
-  /** Returns the distance in kilometers between two points on the planet Earth, calculated by the
-    * spherical law of cosines (https://en.wikipedia.org/wiki/Great-circle_distance#Formulas).
-    * @param p1 the coordinates of the first point
-    * @param p2 the coordinates of the second point
-    * @return the distance in kilometers between two points on the planet Earth.
+  /** Returns the distance in kilometers between two points on the planet Earth, calculated by the spherical law of
+    * cosines (https://en.wikipedia.org/wiki/Great-circle_distance#Formulas).
+    * @param p1
+    *   the coordinates of the first point
+    * @param p2
+    *   the coordinates of the second point
+    * @return
+    *   the distance in kilometers between two points on the planet Earth.
     */
   def distance(p1: Coordinates, p2: Coordinates) =
     distanceFrom(p1)(p2)
 
-  /** Returns a function that measures the distance to the point `p1` on the planet Earth, calculated
-    * by the spherical law of cosines (https://en.wikipedia.org/wiki/Great-circle_distance#Formulas).
-    * @param p1 the coordinates of the first point
-    * @return a function that given a point `p2` returns the distance in kilometers to the point `p1`.
+  /** Returns a function that measures the distance to the point `p1` on the planet Earth, calculated by the spherical
+    * law of cosines (https://en.wikipedia.org/wiki/Great-circle_distance#Formulas).
+    * @param p1
+    *   the coordinates of the first point
+    * @return
+    *   a function that given a point `p2` returns the distance in kilometers to the point `p1`.
     */
   def distanceFrom(p1: Coordinates): Coordinates => Double = {
     val lat1 = toRadians(p1._1)

--- a/core/src/main/scala/com/velocidi/apso/Implicits.scala
+++ b/core/src/main/scala/com/velocidi/apso/Implicits.scala
@@ -103,9 +103,10 @@ object Implicits {
     */
   final implicit class ApsoMap[A, B](val map: Map[A, B]) extends AnyVal {
 
-    /** Merges a given map with this map. The map is constructed as follows: <ul> <li>Keys present in one of thw two
-      * maps are present in the merged map; <li>Keys in both maps are present in the merged map with a value given by
-      * `f(thisValue, thatValue)`; </ul>
+    /** Merges a given map with this map. The map is constructed as follows:
+      *   - Keys present in one of thw two maps are present in the merged map;
+      *   - Keys in both maps are present in the merged map with a value given by `f(thisValue, thatValue)`;
+      *
       * @param that
       *   the map to be merged with this map
       * @param f

--- a/core/src/main/scala/com/velocidi/apso/Implicits.scala
+++ b/core/src/main/scala/com/velocidi/apso/Implicits.scala
@@ -8,24 +8,31 @@ import scala.util.{Random, Try}
   */
 object Implicits {
 
-  /** Implicit class that provides new methods for sequences for which their concrete type is
-    * important.
-    * @param seq the sequence to which the new methods are provided
-    * @tparam T the type of the elements in the sequence
-    * @tparam CC the concrete type of the sequence
+  /** Implicit class that provides new methods for sequences for which their concrete type is important.
+    * @param seq
+    *   the sequence to which the new methods are provided
+    * @tparam T
+    *   the type of the elements in the sequence
+    * @tparam CC
+    *   the concrete type of the sequence
     */
   final implicit class ApsoSeqTyped[T, CC[X] <: Seq[X]](val seq: CC[T]) extends AnyVal {
 
-    /** Merges this sequence with another traversable assuming that both collections are already
-      * sorted. This method eagerly evaluates all the elements of both collections, even if they are
-      * lazy collections. For that reason, infinite sequences are not supported.
-      * @param it the traversable collection to merge with this one
-      * @param bf combiner factory which provides a combiner
-      * @param ord the ordering with which the collections are sorted and with which the merged
-      *            collection is to be returned
-      * @tparam U element type of the resulting collection
-      * @tparam That type of the resulting collection
-      * @return this sequence merged with the given traversable
+    /** Merges this sequence with another traversable assuming that both collections are already sorted. This method
+      * eagerly evaluates all the elements of both collections, even if they are lazy collections. For that reason,
+      * infinite sequences are not supported.
+      * @param it
+      *   the traversable collection to merge with this one
+      * @param bf
+      *   combiner factory which provides a combiner
+      * @param ord
+      *   the ordering with which the collections are sorted and with which the merged collection is to be returned
+      * @tparam U
+      *   element type of the resulting collection
+      * @tparam That
+      *   type of the resulting collection
+      * @return
+      *   this sequence merged with the given traversable
       */
     def mergeSorted[U >: T, That](
         it: IterableOnce[U]
@@ -61,17 +68,19 @@ object Implicits {
   }
 
   /** Implicit class that provides new methods for iterable-once collections.
-    * @param it the iterable-once collection to which the new methods are provided.
+    * @param it
+    *   the iterable-once collection to which the new methods are provided.
     */
   final implicit class ApsoIterableOnce[T](val it: IterableOnce[T]) extends AnyVal {
 
     /** Returns the average of the elements of this collection.
-      * @param num either an instance of `Numeric` or an instance of `Fractional`, defining a set of
-      *            numeric operations which includes the `+` and the `/` operators to be used in
-      *            forming the average.
-      * @tparam A the result type of the `/` operator
-      * @return the average of all elements of this collection with respect to the `+` and `/`
-      *         operators in `num`.
+      * @param num
+      *   either an instance of `Numeric` or an instance of `Fractional`, defining a set of numeric operations which
+      *   includes the `+` and the `/` operators to be used in forming the average.
+      * @tparam A
+      *   the result type of the `/` operator
+      * @return
+      *   the average of all elements of this collection with respect to the `+` and `/` operators in `num`.
       */
     def average[A >: T](implicit num: Numeric[A]): A = {
       val div: (A, A) => A = num match {
@@ -89,19 +98,20 @@ object Implicits {
   }
 
   /** Implicit class that provides new methods for maps.
-    * @param map the map to which the new methods are provided.
+    * @param map
+    *   the map to which the new methods are provided.
     */
   final implicit class ApsoMap[A, B](val map: Map[A, B]) extends AnyVal {
 
-    /** Merges a given map with this map. The map is constructed as follows:
-      * <ul>
-      *   <li>Keys present in one of thw two maps are present in the merged map;
-      *   <li>Keys in both maps are present in the merged map with a value given
-      *       by `f(thisValue, thatValue)`;
-      * </ul>
-      * @param that the map to be merged with this map
-      * @param f the function used to merge two values with the same key
-      * @return the merged map.
+    /** Merges a given map with this map. The map is constructed as follows: <ul> <li>Keys present in one of thw two
+      * maps are present in the merged map; <li>Keys in both maps are present in the merged map with a value given by
+      * `f(thisValue, thatValue)`; </ul>
+      * @param that
+      *   the map to be merged with this map
+      * @param f
+      *   the function used to merge two values with the same key
+      * @return
+      *   the merged map.
       */
     def twoWayMerge(that: Map[A, B])(f: (B, B) => B): Map[A, B] =
       map.foldLeft(that) { case (thatMap, (key, mapValue)) =>
@@ -111,33 +121,40 @@ object Implicits {
         }
       }
 
-    /** Applies a given function to all keys of this map. In case `f` is not
-      * injective, the behaviour is undefined.
-      * @param f the function to apply to all keys of this map
-      * @return the resulting map with the keys mapped with function `f`.
+    /** Applies a given function to all keys of this map. In case `f` is not injective, the behaviour is undefined.
+      * @param f
+      *   the function to apply to all keys of this map
+      * @return
+      *   the resulting map with the keys mapped with function `f`.
       */
     def mapKeys[C](f: A => C): Map[C, B] =
       map.map { case (k, v) => f(k) -> v }
   }
 
   /** Implicit class that provides new methods for random number generators.
-    * @param rand the `Random` instance to which the new methods are provided.
+    * @param rand
+    *   the `Random` instance to which the new methods are provided.
     */
   final implicit class ApsoRandom(val rand: Random) extends AnyVal {
 
     /** Chooses a random element from an indexed sequence.
-      * @param seq the indexed sequence of elements to choose from
-      * @tparam T the type of the elements
-      * @return the selected element wrapped in a `Some` if `seq` has at least one element, `None`
-      *         otherwise.
+      * @param seq
+      *   the indexed sequence of elements to choose from
+      * @tparam T
+      *   the type of the elements
+      * @return
+      *   the selected element wrapped in a `Some` if `seq` has at least one element, `None` otherwise.
       */
     def choose[T](seq: IndexedSeq[T]): Option[T] =
       if (seq.isEmpty) None else Some(seq(rand.nextInt(seq.length)))
 
     /** Chooses n random element from a sequence.
-      * @param seq the sequence of elements to choose from
-      * @tparam T the type of the elements
-      * @return the selected elements
+      * @param seq
+      *   the sequence of elements to choose from
+      * @tparam T
+      *   the type of the elements
+      * @return
+      *   the selected elements
       */
     def chooseN[T](seq: Seq[T], n: Int): Seq[T] = {
       @tailrec
@@ -152,15 +169,19 @@ object Implicits {
     }
 
     /** Chooses an element of a sequence according to a weight function.
-      * @param seq the elements to choose from
-      * @param valueFunc the function that maps elements to weights
-      * @param r the random value used to select the elements. If the default random value is used,
-      *          the weighted selection uses 1.0 as the sum of all weights. To use another scale of
-      *          weights, a random value between 0.0 and the maximum weight should be passed.
-      * @tparam T the type of the elements
-      * @return the selected element wrapped in a `Some` if some element was chosen, `None`
-      *         otherwise. Not choosing any element can happen if the weights of the elements do not
-      *         sum up to the maximum value of `r`.
+      * @param seq
+      *   the elements to choose from
+      * @param valueFunc
+      *   the function that maps elements to weights
+      * @param r
+      *   the random value used to select the elements. If the default random value is used, the weighted selection uses
+      * 1.0 as the sum of all weights. To use another scale of weights, a random value between 0.0 and the maximum
+      * weight should be passed.
+      * @tparam T
+      *   the type of the elements
+      * @return
+      *   the selected element wrapped in a `Some` if some element was chosen, `None` otherwise. Not choosing any
+      *   element can happen if the weights of the elements do not sum up to the maximum value of `r`.
       */
     def monteCarlo[T](seq: Iterable[T], valueFunc: T => Double, r: Double): Option[T] =
       if (seq.isEmpty) None
@@ -171,20 +192,25 @@ object Implicits {
       }
 
     /** Chooses an element of a sequence according to a weight function.
-      * @param seq the pairs (element, probability) to choose from
-      * @tparam T the type of the elements in the sequence
-      * @return the selected element wrapped in a `Some` if some element was chosen, `None`
-      *         otherwise. Not choosing any element can happen if the weights of the elements do not
-      *         sum up to the maximum value of `r`.
+      * @param seq
+      *   the pairs (element, probability) to choose from
+      * @tparam T
+      *   the type of the elements in the sequence
+      * @return
+      *   the selected element wrapped in a `Some` if some element was chosen, `None` otherwise. Not choosing any
+      *   element can happen if the weights of the elements do not sum up to the maximum value of `r`.
       */
     @inline def monteCarlo[T](seq: Iterable[(T, Double)], r: Double = rand.nextDouble()): Option[T] =
       monteCarlo(seq, { p: (T, Double) => p._2 }, r).map(_._1)
 
-    /** Chooses a random element of a traversable using the reservoir sampling technique, traversing
-      * only once the given sequence.
-      * @param seq the elements to choose from
-      * @tparam T the type of the elements
-      * @return the selected element wrapped in a `Some`, or `None` if the traversable is empty.
+    /** Chooses a random element of a traversable using the reservoir sampling technique, traversing only once the given
+      * sequence.
+      * @param seq
+      *   the elements to choose from
+      * @tparam T
+      *   the type of the elements
+      * @return
+      *   the selected element wrapped in a `Some`, or `None` if the traversable is empty.
       */
     def reservoirSample[T](seq: IterableOnce[T]): Option[T] =
       seq.iterator
@@ -194,9 +220,12 @@ object Implicits {
         ._1
 
     /** Returns an infinite stream of weighted samples of a sequence.
-      * @param seq the elements to choose from
-      * @tparam T the type of the elements
-      * @return an infinite stream of weighted samples of a sequence.
+      * @param seq
+      *   the elements to choose from
+      * @tparam T
+      *   the type of the elements
+      * @return
+      *   an infinite stream of weighted samples of a sequence.
       */
     def samples[T](seq: Iterable[T], valueFunc: T => Double): Iterator[T] = {
       if (seq.isEmpty) Iterator.empty
@@ -241,19 +270,23 @@ object Implicits {
     }
 
     /** Returns an infinite stream of weighted samples of a sequence.
-      * @param seq the pairs (element, probability) to choose from
-      * @tparam T the type of the elements
-      * @return an infinite stream of weighted samples of a sequence.
+      * @param seq
+      *   the pairs (element, probability) to choose from
+      * @tparam T
+      *   the type of the elements
+      * @return
+      *   an infinite stream of weighted samples of a sequence.
       */
     @inline def samples[T](seq: Iterable[(T, Double)]): Iterator[T] =
       samples(seq, { p: (T, Double) => p._2 }).map(_._1)
 
-    /** Returns a decreasingly ordered stream of n doubles in [0, 1], according to a
-      * uniform distribution.
-      * More Info: BENTLEY, SAXE, Generating Sorted Lists of Random Numbers
+    /** Returns a decreasingly ordered stream of n doubles in [0, 1], according to a uniform distribution. More Info:
+      * BENTLEY, SAXE, Generating Sorted Lists of Random Numbers
       *
-      * @param n amount of numbers to generate
-      * @return ordered stream of doubles
+      * @param n
+      *   amount of numbers to generate
+      * @return
+      *   ordered stream of doubles
       */
     def decreasingUniformStream(n: Int): immutable.LazyList[Double] =
       immutable.LazyList
@@ -261,37 +294,45 @@ object Implicits {
         .tail
         .map(_._2)
 
-    /** Returns an increasingly ordered stream of n doubles in [0, 1], according to a
-      * uniform distribution.
-      * More Info: BENTLEY, SAXE, Generating Sorted Lists of Random Numbers
+    /** Returns an increasingly ordered stream of n doubles in [0, 1], according to a uniform distribution. More Info:
+      * BENTLEY, SAXE, Generating Sorted Lists of Random Numbers
       *
-      * @param n amount of numbers to generate
-      * @return ordered stream of doubles
+      * @param n
+      *   amount of numbers to generate
+      * @return
+      *   ordered stream of doubles
       */
     def increasingUniformStream(n: Int): immutable.LazyList[Double] =
       decreasingUniformStream(n).map(1 - _)
   }
 
   /** Implicit class that provides new methods for closeable resources.
-    * @param res the closeable resource to which the new methods are provided.
+    * @param res
+    *   the closeable resource to which the new methods are provided.
     */
   final implicit class ApsoCloseable[U <: AutoCloseable](val res: U) extends AnyVal {
 
     /** Uses this resource and closes it afterwards.
-      * @param f the block of code to execute using this resource
-      * @tparam T the return type of the code block.
-      * @return the value returned by the code block.
+      * @param f
+      *   the block of code to execute using this resource
+      * @tparam T
+      *   the return type of the code block.
+      * @return
+      *   the value returned by the code block.
       */
     def use[T](f: U => T): T = TryWith(res)(f).get
 
     /** Uses this resource and closes it afterwards.
       *
-      * Any exception thrown by the code block or during the call to `close()` of the `AutoCloseable` resource
-      * is caught and presented as a `Failure` in return value.
+      * Any exception thrown by the code block or during the call to `close()` of the `AutoCloseable` resource is caught
+      * and presented as a `Failure` in return value.
       *
-      * @param f the block of code to execute using this resource
-      * @tparam T the return type of the code block.
-      * @return a `Try` of the value returned by the code block.
+      * @param f
+      *   the block of code to execute using this resource
+      * @tparam T
+      *   the return type of the code block.
+      * @return
+      *   a `Try` of the value returned by the code block.
       */
     def tryUse[T](f: U => T): Try[T] = TryWith(res)(f)
   }

--- a/core/src/main/scala/com/velocidi/apso/NetUtils.scala
+++ b/core/src/main/scala/com/velocidi/apso/NetUtils.scala
@@ -8,7 +8,8 @@ object NetUtils {
 
   /** Returns an unused port.
     *
-    * @return an unused port.
+    * @return
+    *   an unused port.
     */
   def availablePort(): Int = {
     val socket = new ServerSocket(0)

--- a/core/src/main/scala/com/velocidi/apso/ProgressBar.scala
+++ b/core/src/main/scala/com/velocidi/apso/ProgressBar.scala
@@ -1,11 +1,14 @@
 package com.velocidi.apso
 
 /** A widget for printing a dynamic progress bar in a console.
-  * @param total the number representing the full progress bar
-  * @param width the line width of the progress bar
-  * @param throughputUnit the throughput unit that is being measured
-  * @param throughputTransformer a function to transform the measured throughput
-  *                              value, before displaying it
+  * @param total
+  *   the number representing the full progress bar
+  * @param width
+  *   the line width of the progress bar
+  * @param throughputUnit
+  *   the throughput unit that is being measured
+  * @param throughputTransformer
+  *   a function to transform the measured throughput value, before displaying it
   */
 case class ProgressBar(
     total: Long = 100,
@@ -31,7 +34,8 @@ case class ProgressBar(
   }
 
   /** Increase the progress by the given number of units.
-    * @param inc the number of progress units to increase
+    * @param inc
+    *   the number of progress units to increase
     */
   def tick(inc: Long): Unit = {
     if (!isFinished) {
@@ -65,7 +69,8 @@ case class ProgressBar(
   }
 
   /** Returns `true` if this progress bar is full.
-    * @return `true` if this progress bar is full, `false` otherwise.
+    * @return
+    *   `true` if this progress bar is full, `false` otherwise.
     */
   def isFinished = done >= total
 }

--- a/core/src/main/scala/com/velocidi/apso/Reflect.scala
+++ b/core/src/main/scala/com/velocidi/apso/Reflect.scala
@@ -5,19 +5,27 @@ package com.velocidi.apso
 object Reflect {
 
   /** Returns a new instance of the given class using the default constructor.
-    * @param className the qualified name of the class to instantiate
-    * @tparam T the type of the class to instantiate
-    * @return a new instance of the given class.
+    * @param className
+    *   the qualified name of the class to instantiate
+    * @tparam T
+    *   the type of the class to instantiate
+    * @return
+    *   a new instance of the given class.
     */
   def newInstance[T](className: String): T =
     Class.forName(className).newInstance.asInstanceOf[T]
 
   /** Returns a companion object by its qualified name.
-    * @param objName the name of the object
-    * @param man a manifest of the object to return
-    * @tparam T the type of the object to return
-    * @return the companion object with the given name.
-    * @todo use Scala reflection for doing this operation.
+    * @param objName
+    *   the name of the object
+    * @param man
+    *   a manifest of the object to return
+    * @tparam T
+    *   the type of the object to return
+    * @return
+    *   the companion object with the given name.
+    * @todo
+    *   use Scala reflection for doing this operation.
     */
   def companion[T](objName: String)(implicit man: Manifest[T]): T =
     Class.forName(objName + "$").getField("MODULE$").get(man.runtimeClass).asInstanceOf[T]

--- a/core/src/main/scala/com/velocidi/apso/Retry.scala
+++ b/core/src/main/scala/com/velocidi/apso/Retry.scala
@@ -11,12 +11,18 @@ object Retry {
 
   /** Tries to perform a Future[T] until it succeeds or until maximum retries is reached.
     *
-    * @param maxRetries the number of retries, 10 by default
-    * @param inBetweenSleep the duration to wait between attempts, 100 milliseconds by default
-    * @param f the function that returns the Future[T]
-    * @param ec the implicit execution context
-    * @tparam T the type of what the future completes with
-    * @return the Future[T]
+    * @param maxRetries
+    *   the number of retries, 10 by default
+    * @param inBetweenSleep
+    *   the duration to wait between attempts, 100 milliseconds by default
+    * @param f
+    *   the function that returns the Future[T]
+    * @param ec
+    *   the implicit execution context
+    * @tparam T
+    *   the type of what the future completes with
+    * @return
+    *   the Future[T]
     */
   def retryFuture[T](maxRetries: Int = 10, inBetweenSleep: Option[FiniteDuration] = Some(100.millis))(
       f: => Future[T]
@@ -37,11 +43,16 @@ object Retry {
 
   /** Tries to perform a function `f` until it succeeds or until maximum retries is reached.
     *
-    * @param maxRetries the number of retries, 10 by default
-    * @param inBetweenSleep the duration to wait between attempts, 100 milliseconds by default
-    * @param f the function
-    * @tparam T the type of what the function returns
-    * @return a Try of the `f` function result
+    * @param maxRetries
+    *   the number of retries, 10 by default
+    * @param inBetweenSleep
+    *   the duration to wait between attempts, 100 milliseconds by default
+    * @param f
+    *   the function
+    * @tparam T
+    *   the type of what the function returns
+    * @return
+    *   a Try of the `f` function result
     */
   def retry[T](maxRetries: Int = 10, inBetweenSleep: Option[FiniteDuration] = Some(100.millis))(f: => T): Try[T] = {
     maxRetries match {

--- a/core/src/main/scala/com/velocidi/apso/package.scala
+++ b/core/src/main/scala/com/velocidi/apso/package.scala
@@ -1,6 +1,5 @@
 package com.velocidi
 
-/** Contains ShiftForward's general-purpose utility classes and methods, as well
-  * as extensions of existing ones.
+/** Contains ShiftForward's general-purpose utility classes and methods, as well as extensions of existing ones.
   */
 package object apso

--- a/elasticsearch/src/main/scala/com/velocidi/apso/elasticsearch/ElasticsearchBulkInserter.scala
+++ b/elasticsearch/src/main/scala/com/velocidi/apso/elasticsearch/ElasticsearchBulkInserter.scala
@@ -15,9 +15,8 @@ import io.circe.Json
 
 import com.velocidi.apso.Logging
 
-/** An actor responsible for inserting tracking events into Elasticsearch.
-  * This actor buffers requests until either the configured flush timer is
-  * triggered or the buffer hits the max size.
+/** An actor responsible for inserting tracking events into Elasticsearch. This actor buffers requests until either the
+  * configured flush timer is triggered or the buffer hits the max size.
   */
 class ElasticsearchBulkInserter(
     esConfig: config.Elasticsearch,
@@ -94,12 +93,16 @@ class ElasticsearchBulkInserter(
     }
   }
 
-  /** Given a list of messages that were sent for indexing and the corresponding bulk response, it returns a list
-    * of failed messages and notifies the sender of the successful ones. The retry counter of the failed messages is also incremented.
+  /** Given a list of messages that were sent for indexing and the corresponding bulk response, it returns a list of
+    * failed messages and notifies the sender of the successful ones. The retry counter of the failed messages is also
+    * incremented.
     *
-    * @param sentBuffer the list of messages that were sent for bulk indexing on Elasticsearch
-    * @param bulkResponse the Elasticsearch response for the bulk indexing of the `sentBuffer`
-    * @return an iterator of [[Message]] corresponding to those in `sentBuffer` that failed to index in Elasticsearch
+    * @param sentBuffer
+    *   the list of messages that were sent for bulk indexing on Elasticsearch
+    * @param bulkResponse
+    *   the Elasticsearch response for the bulk indexing of the `sentBuffer`
+    * @return
+    *   an iterator of [[Message]] corresponding to those in `sentBuffer` that failed to index in Elasticsearch
     */
   private[this] def notifyOfSuccessfulAndGetFailed(
       sentBuffer: Iterable[Message],
@@ -238,7 +241,8 @@ object ElasticsearchBulkInserter extends Logging {
   private case class Message(sender: ActorRef, msg: IndexRequest)
 
   /** Message containing an object to insert
-    * @param obj the JSON object to publish
+    * @param obj
+    *   the JSON object to publish
     */
   case class Insert(obj: Json, index: String) {
     def toRequest: IndexRequest = indexInto(index).doc(obj)
@@ -262,9 +266,12 @@ object ElasticsearchBulkInserter extends Logging {
 
   /** Creates a Props for `ElasticsearchBulkInserter`.
     *
-    * @param esConfig the elasticsearch configuration to use
-    * @param logErrorsAsWarnings whether errors should be logged as warnings
-    * @return a `Props` for `ElasticsearchBulkInserter`.
+    * @param esConfig
+    *   the elasticsearch configuration to use
+    * @param logErrorsAsWarnings
+    *   whether errors should be logged as warnings
+    * @return
+    *   a `Props` for `ElasticsearchBulkInserter`.
     */
   def props(esConfig: config.Elasticsearch, logErrorsAsWarnings: Boolean = false): Props =
     Props(new ElasticsearchBulkInserter(esConfig, logErrorsAsWarnings))

--- a/encryption/src/main/scala/com/velocidi/apso/encryption/Decryptor.scala
+++ b/encryption/src/main/scala/com/velocidi/apso/encryption/Decryptor.scala
@@ -11,7 +11,8 @@ import com.velocidi.apso.Logging
 
 /** Utility class to handle decrypting data to string format and, optionally, handle base64 encoded data.
   *
-  * @param decryptor the underlying Cipher object that allows to decrypt the data.
+  * @param decryptor
+  *   the underlying Cipher object that allows to decrypt the data.
   */
 class Decryptor(decryptor: Cipher) extends EncryptionErrorHandling {
   def apply(s: String): Option[String] = decrypt(s)

--- a/encryption/src/main/scala/com/velocidi/apso/encryption/EncryptionUtils.scala
+++ b/encryption/src/main/scala/com/velocidi/apso/encryption/EncryptionUtils.scala
@@ -13,8 +13,8 @@ object BouncyCastleInitializer {
   def apply() = provider
 }
 
-/** Loads and provide a `BouncyCastleProvider` and provides utility methods to encode in base64, load keystores and create
-  * keys from raw password input.
+/** Loads and provide a `BouncyCastleProvider` and provides utility methods to encode in base64, load keystores and
+  * create keys from raw password input.
   */
 trait EncryptionUtils extends EncryptionErrorHandling {
   val provider = BouncyCastleInitializer()

--- a/encryption/src/main/scala/com/velocidi/apso/encryption/Encryptor.scala
+++ b/encryption/src/main/scala/com/velocidi/apso/encryption/Encryptor.scala
@@ -11,7 +11,8 @@ import com.velocidi.apso.Logging
 
 /** Utility class to handle encrypting data to string format and, optionally, handle base64 encoded data.
   *
-  * @param encryptor the underlying Cipher object that allows to encrypt the data.
+  * @param encryptor
+  *   the underlying Cipher object that allows to encrypt the data.
   */
 class Encryptor(encryptor: Cipher) extends EncryptionErrorHandling with Logging {
   def apply(data: String) = encrypt(data)

--- a/hashing/src/main/scala/com/velocidi/apso/hashing/Implicits.scala
+++ b/hashing/src/main/scala/com/velocidi/apso/hashing/Implicits.scala
@@ -7,17 +7,20 @@ import com.twmacinta.util.MD5
 object Implicits {
 
   /** Implicit class that provides new hashing methods for strings.
-    * @param s the string to which the new hashing methods are provided.
+    * @param s
+    *   the string to which the new hashing methods are provided.
     */
   final implicit class ApsoHashingString(val s: String) extends AnyVal {
 
     /** Returns the MD5 of this string.
-      * @return the MD5 of this string.
+      * @return
+      *   the MD5 of this string.
       */
     def md5: String = new MD5(s).asHex
 
     /** Returns the MurmurHash3 of this string.
-      * @return the MurmurHash3 of this string.
+      * @return
+      *   the MurmurHash3 of this string.
       */
     def murmurHash: Long = MurmurHash3.MurmurHash3_x64_64(s.getBytes, 9001)
   }

--- a/io/src/main/scala/com/velocidi/apso/io/FileDescriptor.scala
+++ b/io/src/main/scala/com/velocidi/apso/io/FileDescriptor.scala
@@ -4,18 +4,20 @@ import java.io.InputStream
 
 import scala.io.Source
 
-/** A representation of a file stored in an arbitrary location. A descriptor includes logic to
-  * copy files to and from a local filesystem, as well as filesystem navigation logic.
+/** A representation of a file stored in an arbitrary location. A descriptor includes logic to copy files to and from a
+  * local filesystem, as well as filesystem navigation logic.
   */
 trait FileDescriptor {
 
   /** Returns the unique identifier of this file in its location.
-    * @return the unique identifier of this file in its location.
+    * @return
+    *   the unique identifier of this file in its location.
     */
   def path: String
 
   /** The name of the file associated with the file descriptor.
-    * @return the file name.
+    * @return
+    *   the file name.
     */
   def name: String
 
@@ -27,94 +29,111 @@ trait FileDescriptor {
     */
   def size: Long
 
-  /** Downloads the file to the given local destination.
-    * Both the source and the destination must point to a file.
+  /** Downloads the file to the given local destination. Both the source and the destination must point to a file.
     *
-    * @param localTarget the local destination to which this file should be downloaded.
-    *                    The path must be absolute path to the final file.
-    * @param safeDownloading downloads the file to filename + ".tmp" and renames it to the original
-    *                        name if the download was successful.
-    * @return `true` if the download was successful, `false` otherwise.
+    * @param localTarget
+    *   the local destination to which this file should be downloaded. The path must be absolute path to the final file.
+    * @param safeDownloading
+    *   downloads the file to filename + ".tmp" and renames it to the original name if the download was successful.
+    * @return
+    *   `true` if the download was successful, `false` otherwise.
     */
   def download(localTarget: LocalFileDescriptor, safeDownloading: Boolean = false): Boolean
 
-  /** Uploads a local file to this file's location.
-    * Both the source and the target must point to a file.
+  /** Uploads a local file to this file's location. Both the source and the target must point to a file.
     *
-    * @param localTarget the local file that should be uploaded.
-    *             The path must be absolute path to the final file.
-    * @return `true` if the upload was successful, `false` otherwise.
+    * @param localTarget
+    *   the local file that should be uploaded. The path must be absolute path to the final file.
+    * @return
+    *   `true` if the upload was successful, `false` otherwise.
     */
   def upload(localTarget: LocalFileDescriptor): Boolean
 
-  /** Uploads an input stream to this file's location.
-    * The target must point to a file.
+  /** Uploads an input stream to this file's location. The target must point to a file.
     *
-    * @param inputStream the input stream that should be uploaded.
-    * @param length the input stream length (leaving this as `None` can have performance implications)
-    * @return `true` if the upload was successful, `false` otherwise.
+    * @param inputStream
+    *   the input stream that should be uploaded.
+    * @param length
+    *   the input stream length (leaving this as `None` can have performance implications)
+    * @return
+    *   `true` if the upload was successful, `false` otherwise.
     */
   def upload(inputStream: InputStream, length: Option[Long]): Boolean
 
   /** Returns an input stream for the contents of this file.
-    * @param offset bytes to skip before reading the file.
-    * @return an input stream for the contents of this file.
+    * @param offset
+    *   bytes to skip before reading the file.
+    * @return
+    *   an input stream for the contents of this file.
     */
   def stream(offset: Long = 0L): InputStream
 
   /** Returns an iterator with the lines of this file.
-    * @return an iterator with the lines of this file.
+    * @return
+    *   an iterator with the lines of this file.
     */
   def lines(): Iterator[String] = Source.fromInputStream(stream()).getLines()
 
   /** Returns true if the fd points to a directory
-    * @return true if the fd points to a directory
+    * @return
+    *   true if the fd points to a directory
     */
   def isDirectory: Boolean
 
   /** Lists the files in the current file descriptor directory
-    * @return a iterator of file descriptors
+    * @return
+    *   a iterator of file descriptors
     */
   def list: Iterator[FileDescriptor]
 
   /** Lists all files down the file hierarchy tree that whose relative path match the given prefix
-    * @param prefix the prefix to match given each file relative path to the current directory
-    * @return a iterator of file descriptors
+    * @param prefix
+    *   the prefix to match given each file relative path to the current directory
+    * @return
+    *   a iterator of file descriptors
     */
   def listAllFilesWithPrefix(prefix: String): Iterator[FileDescriptor]
 
   /** Returns the file descriptor `n` node up in the filesystem path.
-    * @param n the number of parent nodes to go back.
-    * @return the file descriptor `n` node up in the filesystem path.
+    * @param n
+    *   the number of parent nodes to go back.
+    * @return
+    *   the file descriptor `n` node up in the filesystem path.
     */
   def parent(n: Int = 1): FileDescriptor
 
   /** Adds a new child node to the filesystem path.
-    * @param name the node name.
-    * @return the new file descriptor with the updated path
+    * @param name
+    *   the node name.
+    * @return
+    *   the new file descriptor with the updated path
     */
   def child(name: String): FileDescriptor
 
   /** Adds a new child node to the filesystem path.
-    * @param name the node name.
-    * @return the new file descriptor with the updated path
+    * @param name
+    *   the node name.
+    * @return
+    *   the new file descriptor with the updated path
     */
   def /(name: String): FileDescriptor = child(name)
 
   /** Adds multiple new child nodes to the filesystem path.
-    * @param names the node names to add.
-    * @return the new file descriptor with the updated path
+    * @param names
+    *   the node names to add.
+    * @return
+    *   the new file descriptor with the updated path
     */
   def children(names: String*): FileDescriptor =
     names.foldLeft(this)((acc, c) => acc.child(c))
 
-  /** Changes the path of the file descriptor using unix's cd syntax related to the current directory.
-    * Ex: Go back to directories: ../..
-    *     Go to child directories: foo/bar
-    *     Go to sibling directory: ../foo
-    * Absolute path changes are not supported.
-    * @param pathString the cd command
-    * @return the new file descriptor with the updated path
+  /** Changes the path of the file descriptor using unix's cd syntax related to the current directory. Ex: Go back to
+    * directories: ../.. Go to child directories: foo/bar Go to sibling directory: ../foo Absolute path changes are not
+    * supported.
+    * @param pathString
+    *   the cd command
+    * @return
+    *   the new file descriptor with the updated path
     */
   def cd(pathString: String): FileDescriptor = {
     pathString.split("/").toList.foldLeft(this) {
@@ -125,29 +144,36 @@ trait FileDescriptor {
   }
 
   /** Returns a new file descriptor pointing to a sibling of the current file descriptor
-    * @param name the file name of the new file descriptor
-    * @return a new file descriptor pointing to a sibling of the current file descriptor
+    * @param name
+    *   the file name of the new file descriptor
+    * @return
+    *   a new file descriptor pointing to a sibling of the current file descriptor
     */
   def sibling(name: String): FileDescriptor = sibling(_ => name)
 
   /** Returns a new file descriptor pointing to a sibling of the current file descriptor
-    * @param f a function that returns a new name from the current name of the file descriptor
-    * @return a new file descriptor pointing to a sibling of the current file descriptor
+    * @param f
+    *   a function that returns a new name from the current name of the file descriptor
+    * @return
+    *   a new file descriptor pointing to a sibling of the current file descriptor
     */
   def sibling(f: String => String): FileDescriptor = parent().child(f(name))
 
   /** Returns true if the file pointed by the file descriptor exists
-    * @return true if the file pointed by the file descriptor exists
+    * @return
+    *   true if the file pointed by the file descriptor exists
     */
   def exists: Boolean
 
   /** Deletes the file associated with the file descriptor
-    * @return `true` if the delete was successful, `false` otherwise.
+    * @return
+    *   `true` if the delete was successful, `false` otherwise.
     */
   def delete(): Boolean
 
   /** Creates intermediary directories
-    * @return true if the creation of successful, false otherwise.
+    * @return
+    *   true if the creation of successful, false otherwise.
     */
   def mkdirs(): Boolean
 }
@@ -155,8 +181,10 @@ trait FileDescriptor {
 object FileDescriptor {
 
   /** Creates the specific File descriptor from a URI
-    * @param uri the URI
-    * @return the specific file descriptor given the supported protocols
+    * @param uri
+    *   the URI
+    * @return
+    *   the specific file descriptor given the supported protocols
     */
   def apply(uri: String): FileDescriptor = apply(uri, config.Credentials())
 
@@ -170,8 +198,10 @@ object FileDescriptor {
   }
 
   /** Splits the protocol from the path for a given URI
-    * @param uri the URI
-    * @return a tuple of (protocol, path)
+    * @param uri
+    *   the URI
+    * @return
+    *   a tuple of (protocol, path)
     */
   private def protocol(uri: String) = uri.split("://").toList match {
     case protocol :: path :: Nil => (protocol, path)

--- a/io/src/main/scala/com/velocidi/apso/io/FileDescriptor.scala
+++ b/io/src/main/scala/com/velocidi/apso/io/FileDescriptor.scala
@@ -127,9 +127,14 @@ trait FileDescriptor {
   def children(names: String*): FileDescriptor =
     names.foldLeft(this)((acc, c) => acc.child(c))
 
-  /** Changes the path of the file descriptor using unix's cd syntax related to the current directory. Ex: Go back to
-    * directories: ../.. Go to child directories: foo/bar Go to sibling directory: ../foo Absolute path changes are not
-    * supported.
+  /** Changes the path of the file descriptor using unix's cd syntax related to the current directory.
+    *
+    * Ex:
+    *   - Go back to directories: ../..
+    *   - Go to child directories: foo/bar
+    *   - Go to sibling directory: ../foo
+    *
+    * Absolute path changes are not supported.
     * @param pathString
     *   the cd command
     * @return

--- a/io/src/main/scala/com/velocidi/apso/io/FileDescriptorCredentials.scala
+++ b/io/src/main/scala/com/velocidi/apso/io/FileDescriptorCredentials.scala
@@ -14,34 +14,40 @@ package com.velocidi.apso.io
   * }
   * }}}
   *
-  * The `default` is optional and is used as a fallback when the
-  * file descriptor id matches none of the credentials ids.
+  * The `default` is optional and is used as a fallback when the file descriptor id matches none of the credentials ids.
   *
-  * @tparam Conf The type of credential config that is extracted
-  * @tparam CredObj The type of credential object that is extracted
+  * @tparam Conf
+  *   The type of credential config that is extracted
+  * @tparam CredObj
+  *   The type of credential object that is extracted
   */
 trait FileDescriptorCredentials[Conf, CredObj] {
 
-  /** Returns an unique id from the given file descriptor path to use when
-    * accessing the config
-    * @param path the file descriptor path
-    * @return an unique id from the given file descriptor path
+  /** Returns an unique id from the given file descriptor path to use when accessing the config
+    * @param path
+    *   the file descriptor path
+    * @return
+    *   an unique id from the given file descriptor path
     */
   protected def id(path: String): String
 
   /** Creates a credential object `T` from the file descriptor specific config
-    * @param fdConfig the config containing specific keys required to create a
-    *                 credential object `T` for the file descriptor
-    * @return the credential object `T`
+    * @param fdConfig
+    *   the config containing specific keys required to create a credential object `T` for the file descriptor
+    * @return
+    *   the credential object `T`
     */
   protected def createCredentials(fdId: String, fdConfig: Conf): CredObj
 
-  /** Reads from the config file and given the file descriptor path converted to
-    * an unique id by the `ìd` function, extracts a credentials object `T`.
+  /** Reads from the config file and given the file descriptor path converted to an unique id by the `ìd` function,
+    * extracts a credentials object `T`.
     *
-    * @param conf the config file with the credentials keys
-    * @param path the file descriptor path to be converted to an unique id
-    * @return the credential object `T`
+    * @param conf
+    *   the config file with the credentials keys
+    * @param path
+    *   the file descriptor path to be converted to an unique id
+    * @return
+    *   the credential object `T`
     */
   def read(conf: config.Credentials.Protocol[Conf], path: String): Option[CredObj] = {
     val fdId = id(path)

--- a/io/src/main/scala/com/velocidi/apso/io/InsistentInputStream.scala
+++ b/io/src/main/scala/com/velocidi/apso/io/InsistentInputStream.scala
@@ -11,9 +11,12 @@ import com.velocidi.apso.Logging
 /** A InputStream that wraps another InputStream, retrying failed reads. This is useful for input streams that can have
   * transient failures (eg HTTP input streams).
   *
-  * @param streamBuilder function that returns a new stream starting at a certain position.
-  * @param maxRetries maximum number of times to retry a read
-  * @param backoff optional duration to wait between retries
+  * @param streamBuilder
+  *   function that returns a new stream starting at a certain position.
+  * @param maxRetries
+  *   maximum number of times to retry a read
+  * @param backoff
+  *   optional duration to wait between retries
   */
 class InsistentInputStream(
     streamBuilder: (Long) => InputStream,

--- a/io/src/main/scala/com/velocidi/apso/io/LazySequenceInputStream.scala
+++ b/io/src/main/scala/com/velocidi/apso/io/LazySequenceInputStream.scala
@@ -2,12 +2,12 @@ package com.velocidi.apso.io
 
 import java.io.InputStream
 
-/** Provides the same functionality as `java.io.SequenceInputStream`, i.e. a
-  * `SequenceInputStream` represents the logical concatenation of other input streams.
-  * Unlike `SequenceInputStream`, this implementation will open the concatenated input
-  * streams lazily (as needed). At any point while reading from the stream, only one
-  * underlying `InputStream` should be open.
-  * @param streams A sequence of `InputStream` thunks
+/** Provides the same functionality as `java.io.SequenceInputStream`, i.e. a `SequenceInputStream` represents the
+  * logical concatenation of other input streams. Unlike `SequenceInputStream`, this implementation will open the
+  * concatenated input streams lazily (as needed). At any point while reading from the stream, only one underlying
+  * `InputStream` should be open.
+  * @param streams
+  *   A sequence of `InputStream` thunks
   */
 class LazySequenceInputStream(private[this] var streams: Seq[() => InputStream]) extends InputStream {
   private[this] var current: InputStream = null

--- a/io/src/main/scala/com/velocidi/apso/io/LocalFileDescriptor.scala
+++ b/io/src/main/scala/com/velocidi/apso/io/LocalFileDescriptor.scala
@@ -153,10 +153,10 @@ case class LocalFileDescriptor(initialPath: String) extends FileDescriptor with 
 
   def delete(): Boolean = file.delete()
 
-  /** Deletes the directory associated with the file descriptor by recursively deleting all the
-    * directories and files inside it. Symbolic links are not followed and are just deleted as
-    * "regular" files.
-    * @return `true` if the delete was successful, `false` otherwise.
+  /** Deletes the directory associated with the file descriptor by recursively deleting all the directories and files
+    * inside it. Symbolic links are not followed and are just deleted as "regular" files.
+    * @return
+    *   `true` if the delete was successful, `false` otherwise.
     */
   def deleteDir(): Boolean = {
     def aux(fd: LocalFileDescriptor): Boolean = {
@@ -171,8 +171,10 @@ case class LocalFileDescriptor(initialPath: String) extends FileDescriptor with 
   def mkdirs(): Boolean = exists || file.mkdirs()
 
   /** Renames the file pointed by the file descriptor
-    * @param to the file descriptor to be renamed to
-    * @return a Some of the renamed file descriptor if successful, otherwise None.
+    * @param to
+    *   the file descriptor to be renamed to
+    * @return
+    *   a Some of the renamed file descriptor if successful, otherwise None.
     */
   def rename(to: LocalFileDescriptor): Option[LocalFileDescriptor] = {
     to.parent().mkdirs()
@@ -180,7 +182,8 @@ case class LocalFileDescriptor(initialPath: String) extends FileDescriptor with 
   }
 
   /** Writes the given string `str` to the file pointed by the file descriptor
-    * @param str the string to write to the file
+    * @param str
+    *   the string to write to the file
     */
   def write(str: String): Unit = {
     parent().mkdirs()
@@ -188,7 +191,8 @@ case class LocalFileDescriptor(initialPath: String) extends FileDescriptor with 
   }
 
   /** Writes the given byteArray to file pointed by the file descriptor
-    * @param byteArray the byte array to write to the file
+    * @param byteArray
+    *   the byte array to write to the file
     */
   def write(byteArray: Array[Byte]): Unit = {
     parent().mkdirs()
@@ -196,7 +200,8 @@ case class LocalFileDescriptor(initialPath: String) extends FileDescriptor with 
   }
 
   /** Reads the file pointed by the file descriptor and returns it in string format
-    * @return the contents of the file in string format
+    * @return
+    *   the contents of the file in string format
     */
   def readString: String = Source.fromFile(file, "UTF-8").mkString
 

--- a/io/src/main/scala/com/velocidi/apso/io/S3FileDescriptor.scala
+++ b/io/src/main/scala/com/velocidi/apso/io/S3FileDescriptor.scala
@@ -140,41 +140,55 @@ case class S3FileDescriptor(
 object S3FileDescriptor {
 
   /** Creates an S3FileDescriptor from a path string extracting the bucket and the path
-    * @param path the uri without the protocol, containing the bucket and path
-    * @return a s3 file descriptor
+    * @param path
+    *   the uri without the protocol, containing the bucket and path
+    * @return
+    *   a s3 file descriptor
     */
   def apply(path: String): S3FileDescriptor = apply(path, None)
 
   /** Creates an S3FileDescriptor from a path string extracting the bucket and the path
-    * @param path the uri without the protocol, containing the bucket and path
-    * @param credentialsConfig the config containing the credentials
-    * @return a s3 file descriptor
+    * @param path
+    *   the uri without the protocol, containing the bucket and path
+    * @param credentialsConfig
+    *   the config containing the credentials
+    * @return
+    *   a s3 file descriptor
     */
   def apply(path: String, credentialsConfig: config.Credentials.S3): S3FileDescriptor =
     apply(path, credentials.read(credentialsConfig, path))
 
   /** Creates an S3FileDescriptor from a path string extracting the bucket and the path
-    * @param path the uri without the protocol, containing the bucket and path
-    * @param credentials credentials for accessing the s3 bucket
-    * @return a s3 file descriptor
+    * @param path
+    *   the uri without the protocol, containing the bucket and path
+    * @param credentials
+    *   credentials for accessing the s3 bucket
+    * @return
+    *   a s3 file descriptor
     */
   def apply(path: String, credentials: BasicAWSCredentials): S3FileDescriptor = {
     apply(path, Some(SerializableAWSCredentials(credentials)))
   }
 
   /** Creates an S3FileDescriptor from a path string extracting the bucket and the path
-    * @param path the uri without the protocol, containing the bucket and path
-    * @param credentials serializable credentials for accessing the s3 bucket
-    * @return a s3 file descriptor
+    * @param path
+    *   the uri without the protocol, containing the bucket and path
+    * @param credentials
+    *   serializable credentials for accessing the s3 bucket
+    * @return
+    *   a s3 file descriptor
     */
   def apply(path: String, credentials: SerializableAWSCredentials): S3FileDescriptor = {
     apply(path, Some(credentials))
   }
 
   /** Creates an S3FileDescriptor from a path string extracting the bucket and the path
-    * @param path the uri without the protocol, containing the bucket and path
-    * @param credentials optional credentials for accessing the s3 bucket
-    * @return a s3 file descriptor
+    * @param path
+    *   the uri without the protocol, containing the bucket and path
+    * @param credentials
+    *   optional credentials for accessing the s3 bucket
+    * @return
+    *   a s3 file descriptor
     */
   private def apply(path: String, credentials: Option[SerializableAWSCredentials]): S3FileDescriptor = {
     path.split('/').toList match {
@@ -199,8 +213,8 @@ object S3FileDescriptor {
     }
   }
 
-  /** This Map caches S3Buckets so that each S3FileDescriptor does not need to have it's own
-    * internal object to access the bucket.
+  /** This Map caches S3Buckets so that each S3FileDescriptor does not need to have it's own internal object to access
+    * the bucket.
     */
   private val s3Buckets = TrieMap.empty[String, S3Bucket]
 }

--- a/io/src/main/scala/com/velocidi/apso/io/SftpFileDescriptor.scala
+++ b/io/src/main/scala/com/velocidi/apso/io/SftpFileDescriptor.scala
@@ -18,33 +18,22 @@ import net.schmizz.sshj.xfer.InMemorySourceFile
 
 import com.velocidi.apso.Logging
 
-/** A `FileDescriptor` for files served over SFTP. This file descriptor only supports absolute paths.
-  * The SSH connections for a given host are pooled.
+/** A `FileDescriptor` for files served over SFTP. This file descriptor only supports absolute paths. The SSH
+  * connections for a given host are pooled.
   *
   * The URI for this `FileDescriptor` should be in the format:
-  * - `sftp://<username>@<hostname>:<port>/<absolute-path>`
+  *   - `sftp://<username>@<hostname>:<port>/<absolute-path>`
   *
-  * Both the username and port are optional. Additionally, the credentials config expects an object
-  * with the following format:
+  * Both the username and port are optional. Additionally, the credentials config expects an object with the following
+  * format:
   *
-  * `sftp {
-  *    default = {
-  *      username = <username>
-  *      password = <password>
-  *    }
-  *  }`
+  * `sftp { default = { username = <username> password = <password> } }`
   *
-  * Or if using public key authentication:
-  * `sftp {
-  *    default = {
-  *      username = <username>
-  *      keypair-file = <key filename>
-  *      passphrase = <passphrase>
-  *    }
-  *  }`
+  * Or if using public key authentication: `sftp { default = { username = <username> keypair-file = <key filename>
+  * passphrase = <passphrase> } }`
   *
-  * What is considered as an `id` for credentials handling is the `hostname` of the file descriptor,
-  * therefore it is possible to provide credentials for a specific `hostname`.
+  * What is considered as an `id` for credentials handling is the `hostname` of the file descriptor, therefore it is
+  * possible to provide credentials for a specific `hostname`.
   */
 case class SftpFileDescriptor(
     host: String,
@@ -300,7 +289,7 @@ object SftpFileDescriptor {
 
     pool.tryAcquire(leaseAcquireMaxDuration) match {
       case Some(lease) => lease
-      case None        => throw new TimeoutException(s"Failed to acquire a SFTP client within $leaseAcquireMaxDuration.")
+      case None => throw new TimeoutException(s"Failed to acquire a SFTP client within $leaseAcquireMaxDuration.")
     }
   }
 
@@ -354,7 +343,7 @@ object SftpFileDescriptor {
       path.split("/").toList match {
         case Nil              => Nil
         case "" :: hd :: tail => hd :: tail
-        case _                => throw new IllegalArgumentException("Error parsing SFTP URI. Only absolute paths are supported.")
+        case _ => throw new IllegalArgumentException("Error parsing SFTP URI. Only absolute paths are supported.")
       }
 
     SftpFileDescriptor(host, port, username, password, elements, identity)

--- a/io/src/main/scala/com/velocidi/apso/io/SftpFileDescriptor.scala
+++ b/io/src/main/scala/com/velocidi/apso/io/SftpFileDescriptor.scala
@@ -27,10 +27,26 @@ import com.velocidi.apso.Logging
   * Both the username and port are optional. Additionally, the credentials config expects an object with the following
   * format:
   *
-  * `sftp { default = { username = <username> password = <password> } }`
+  * {{{
+  * sftp {
+  *   default = {
+  *     username = <username>
+  *     password = <password>
+  *   }
+  * }
+  * }}}
   *
-  * Or if using public key authentication: `sftp { default = { username = <username> keypair-file = <key filename>
-  * passphrase = <passphrase> } }`
+  * Or if using public key authentication:
+  *
+  * {{{
+  * sftp {
+  *   default = {
+  *     username = <username>
+  *     keypair-file = <key filename>
+  *     passphrase = <passphrase>
+  *   }
+  * }
+  * }}}
   *
   * What is considered as an `id` for credentials handling is the `hostname` of the file descriptor, therefore it is
   * possible to provide credentials for a specific `hostname`.

--- a/log/src/main/scala/com/velocidi/apso/Logging.scala
+++ b/log/src/main/scala/com/velocidi/apso/Logging.scala
@@ -6,8 +6,7 @@ import com.typesafe.scalalogging.Logger
   */
 trait Logging {
 
-  /** The `Logger` object. This logger will have the same name as the concrete class
-    * into which this trait is mixed-in.
+  /** The `Logger` object. This logger will have the same name as the concrete class into which this trait is mixed-in.
     */
   lazy val log = Logger(getClass)
 }
@@ -16,8 +15,7 @@ trait Logging {
   */
 trait StrictLogging {
 
-  /** The `Logger` object. This logger will have the same name as the concrete class
-    * into which this trait is mixed-in.
+  /** The `Logger` object. This logger will have the same name as the concrete class into which this trait is mixed-in.
     */
   val log = Logger(getClass)
 }

--- a/profiling/src/main/scala/com/velocidi/apso/profiling/CpuSampler.scala
+++ b/profiling/src/main/scala/com/velocidi/apso/profiling/CpuSampler.scala
@@ -10,15 +10,17 @@ import com.velocidi.apso.profiling.CpuSampler._
 
 /** A lightweight CPU profiler based on call stack sampling.
   *
-  * When run as a thread, it periodically captures the call stacks of all live threads and maintains
-  * counters for each leaf method. The counters are then dumped to a logger with a given periodicity
-  * (most probably greater than the sampling period). Each data row written to the logger contains a
-  * timestamp, the method profiled, its location in the source code and the associated absolute
-  * counters and relative weight.
+  * When run as a thread, it periodically captures the call stacks of all live threads and maintains counters for each
+  * leaf method. The counters are then dumped to a logger with a given periodicity (most probably greater than the
+  * sampling period). Each data row written to the logger contains a timestamp, the method profiled, its location in the
+  * source code and the associated absolute counters and relative weight.
   *
-  * @param samplePeriod the period between each sample taken
-  * @param flushPeriod the period between each flush to log
-  * @param logger the logger to which results are written
+  * @param samplePeriod
+  *   the period between each sample taken
+  * @param flushPeriod
+  *   the period between each flush to log
+  * @param logger
+  *   the logger to which results are written
   */
 class CpuSampler(samplePeriod: Long = 100, flushPeriod: Long = 10000, logger: Logger = Logger(getClass))
     extends Runnable {
@@ -29,18 +31,18 @@ class CpuSampler(samplePeriod: Long = 100, flushPeriod: Long = 10000, logger: Lo
   private[this] var lastFlush = 0L
   private[this] val entries = mutable.Queue[StackTraceElement]()
 
-  /** Returns a boolean value indicating if the stack trace element should be considered when
-    * profiling or not.
-    * @param elem the stack trace element
-    * @return `true` if the stack trace element should be considered in profiling, `false` otherwise.
+  /** Returns a boolean value indicating if the stack trace element should be considered when profiling or not.
+    * @param elem
+    *   the stack trace element
+    * @return
+    *   `true` if the stack trace element should be considered in profiling, `false` otherwise.
     */
   def shouldProfile(elem: StackTraceElement) = {
     !excludeClassRegex.matcher(elem.getClassName).matches &&
     !excludedMethods.get(elem.getClassName).exists(_ == elem.getMethodName)
   }
 
-  /** Captures the current call stacks of all live threads and stores relevant profiling data about
-    * them.
+  /** Captures the current call stacks of all live threads and stores relevant profiling data about them.
     */
   def sample() = for {
     info <- threadBean.dumpAllThreads(false, false) if info.getThreadId != Thread.currentThread.getId
@@ -48,7 +50,8 @@ class CpuSampler(samplePeriod: Long = 100, flushPeriod: Long = 10000, logger: Lo
   } entries.enqueue(elem)
 
   /** Flushes the stored profiling data to the logger.
-    * @param timestamp the timestamp to use when writing the entries to the logger
+    * @param timestamp
+    *   the timestamp to use when writing the entries to the logger
     */
   def flush(timestamp: Long = System.currentTimeMillis()) = {
     aggregateAll(timestamp).foreach(t => logger.debug(s"$t"))
@@ -88,8 +91,7 @@ class CpuSampler(samplePeriod: Long = 100, flushPeriod: Long = 10000, logger: Lo
     sampleLoop()
   }
 
-  /** Stops the data collecting and flushes the remaining data to the logger, causing the thread to
-    * stop eventually.
+  /** Stops the data collecting and flushes the remaining data to the logger, causing the thread to stop eventually.
     */
   def stop() = {
     active = false
@@ -102,10 +104,14 @@ class CpuSampler(samplePeriod: Long = 100, flushPeriod: Long = 10000, logger: Lo
 object CpuSampler {
 
   /** An entry to be logged.
-    * @param timestamp the timestamp of the data
-    * @param elem the stack trace element
-    * @param count the number of times the element was seen since the last flush
-    * @param perc the percentage of times the element was seen, in the range 0.0 to 100.0
+    * @param timestamp
+    *   the timestamp of the data
+    * @param elem
+    *   the stack trace element
+    * @param count
+    *   the number of times the element was seen since the last flush
+    * @param perc
+    *   the percentage of times the element was seen, in the range 0.0 to 100.0
     */
   case class Entry(timestamp: Long, elem: StackTraceElement, count: Int, perc: Double) {
     override def toString =
@@ -120,8 +126,8 @@ object CpuSampler {
       )
   }
 
-  /** A list of package names that should not be profiled. All child packages of the packages in this
-    * list are also excluded.
+  /** A list of package names that should not be profiled. All child packages of the packages in this list are also
+    * excluded.
     */
   val excludedPackages =
     Seq("sun", "sunw", "com.sun", "com.apple", "apple.awt", "apple.laf", "org.jboss.netty", "scala.concurrent.forkjoin")

--- a/profiling/src/main/scala/com/velocidi/apso/profiling/config/Jmx.scala
+++ b/profiling/src/main/scala/com/velocidi/apso/profiling/config/Jmx.scala
@@ -2,7 +2,9 @@ package com.velocidi.apso.profiling.config
 
 /** Config class for SimpleJmx
   *
-  * @param host the optional host
-  * @param port the optional port
+  * @param host
+  *   the optional host
+  * @param port
+  *   the optional port
   */
 case class Jmx(host: Option[String], port: Option[Int])

--- a/testkit/src/main/scala/com/velocidi/apso/CustomMatchers.scala
+++ b/testkit/src/main/scala/com/velocidi/apso/CustomMatchers.scala
@@ -27,8 +27,8 @@ trait CustomMatchers extends SpecificationLike {
     }
   }
 
-  /** Return a successful MatchResult[T].
-    * This is useful to explicitly expose a value outside a Matcher which can later be accessed with `_.expectable.value`.
+  /** Return a successful MatchResult[T]. This is useful to explicitly expose a value outside a Matcher which can later
+    * be accessed with `_.expectable.value`.
     */
   def offer[T](result: T): MatchResult[T] = Matcher.result(test = true, "ok", createExpectable(result))
 }

--- a/testkit/src/main/scala/com/velocidi/apso/FutureExtraMatchers.scala
+++ b/testkit/src/main/scala/com/velocidi/apso/FutureExtraMatchers.scala
@@ -16,7 +16,8 @@ trait FutureExtraMatchers { this: SpecificationLike =>
 
   implicit class RichFutureExtraMatcher[T: AsResult](m: => T) {
 
-    /** @return a matcher that needs to eventually match, after a given number of retries.
+    /** @return
+      *   a matcher that needs to eventually match, after a given number of retries.
       */
     def eventually(retries: Int): T = EventuallyMatchers.eventually(retries, 100.milliseconds)(m)
   }

--- a/testkit/src/main/scala/com/velocidi/apso/JreVersionTestHelper.scala
+++ b/testkit/src/main/scala/com/velocidi/apso/JreVersionTestHelper.scala
@@ -10,7 +10,7 @@ trait JreVersionTestHelper {
   def jre[T](major: Int, minor: Int)(r: => T)(implicit evidence: AsResult[T]): Result = {
     System.getProperty("java.version") match {
       case VersionRegex(ma, mi) if (ma.toInt, mi.toInt) >= (major, minor) => evidence.asResult(r)
-      case _                                                              => Skipped(s"This test requires JRE >= $major.$minor")
+      case _ => Skipped(s"This test requires JRE >= $major.$minor")
     }
   }
 }

--- a/time/src/main/scala/com/velocidi/apso/time/Implicits.scala
+++ b/time/src/main/scala/com/velocidi/apso/time/Implicits.scala
@@ -8,95 +8,110 @@ import org.joda.time.ReadableInterval
 object Implicits {
 
   /** Implicit class that provides new methods for `LocalDates`.
-    * @param d1 the `LocalDate` to which the new methods are provided.
+    * @param d1
+    *   the `LocalDate` to which the new methods are provided.
     */
   implicit class ApsoTimeLocalDate(val d1: LocalDate) extends AnyVal {
 
     /** Returns a `DateTime` corresponding to this `LocalDate` at UTC midnight.
-      * @return a `DateTime` corresponding to this `LocalDate` at UTC midnight.
+      * @return
+      *   a `DateTime` corresponding to this `LocalDate` at UTC midnight.
       */
     def utcDateTime: DateTime = d1.toDateTime(new LocalTime(0, 0), DateTimeZone.UTC)
 
-    /** Returns a `DateTime` corresponding to this `LocalDate` at the latest valid
-      * time for the date.
-      * @return a `DateTime` corresponding to this `LocalDate` at the latest valid
-      *         time for the date.
+    /** Returns a `DateTime` corresponding to this `LocalDate` at the latest valid time for the date.
+      * @return
+      *   a `DateTime` corresponding to this `LocalDate` at the latest valid time for the date.
       */
     def toDateTimeAtEndOfDay =
       (d1 + 1.day).toDateTimeAtStartOfDay - 1.millis
 
-    /** Returns a `DateTime` corresponding to this `LocalDate` at the latest valid
-      * time for the date on the given `DateTimeZone`.
-      * @param tz the target `DateTimeZone` for the returned `DateTime`
-      * @return a `DateTime` corresponding to this `LocalDate` at the latest valid
-      *         time for the date on the given `DateTimeZone`.
+    /** Returns a `DateTime` corresponding to this `LocalDate` at the latest valid time for the date on the given
+      * `DateTimeZone`.
+      * @param tz
+      *   the target `DateTimeZone` for the returned `DateTime`
+      * @return
+      *   a `DateTime` corresponding to this `LocalDate` at the latest valid time for the date on the given
+      *   `DateTimeZone`.
       */
     def toDateTimeAtEndOfDay(tz: DateTimeZone) =
       (d1 + 1.day).toDateTimeAtStartOfDay(tz) - 1.millis
 
-    /** Returns an iterable interval starting at this `LocalDate` (inclusive) and
-      * ending at the given `LocalDate` (inclusive), with a 1 day step.
-      * @param d2 the ending `LocalDate`
-      * @return an iterable interval starting at this `LocalDate` (inclusive) and
-      *         ending at the given `LocalDate` (inclusive), with a 1 day step.
+    /** Returns an iterable interval starting at this `LocalDate` (inclusive) and ending at the given `LocalDate`
+      * (inclusive), with a 1 day step.
+      * @param d2
+      *   the ending `LocalDate`
+      * @return
+      *   an iterable interval starting at this `LocalDate` (inclusive) and ending at the given `LocalDate` (inclusive),
+      *   with a 1 day step.
       */
     def to(d2: LocalDate) =
       LocalDateInterval(IterableInterval(d1.toDateTimeAtStartOfDay to d2.toDateTimeAtStartOfDay, 1.day, true))
 
-    /** Returns an iterable interval starting at this `LocalDate` (inclusive) and
-      * ending at the given `LocalDate` (exclusive), with a 1 day step.
-      * @param d2 the ending `LocalDate`
-      * @return an iterable interval starting at this `LocalDate` (inclusive) and
-      *         ending at the given `LocalDate` (exclusive), with a 1 day step.
+    /** Returns an iterable interval starting at this `LocalDate` (inclusive) and ending at the given `LocalDate`
+      * (exclusive), with a 1 day step.
+      * @param d2
+      *   the ending `LocalDate`
+      * @return
+      *   an iterable interval starting at this `LocalDate` (inclusive) and ending at the given `LocalDate` (exclusive),
+      *   with a 1 day step.
       */
     def until(d2: LocalDate) =
       LocalDateInterval(IterableInterval(d1.toDateTimeAtStartOfDay to d2.toDateTimeAtStartOfDay, 1.day, false))
   }
 
   /** Implicit class that provides new methods for `DateTimes`.
-    * @param d1 the `DateTime` to which the new methods are provided.
+    * @param d1
+    *   the `DateTime` to which the new methods are provided.
     */
   final implicit class ApsoTimeDateTime(val d1: DateTime) extends AnyVal {
 
     /** Returns a `LocalDate` corresponding to this `DateTime` at UTC.
-      * @return a `LocalDate` corresponding to this `DateTime` at UTC.
+      * @return
+      *   a `LocalDate` corresponding to this `DateTime` at UTC.
       */
     def utcLocalDate: LocalDate = d1.withZone(DateTimeZone.UTC).toLocalDate
 
     /** Returns `true` if the given `DateTime` is in the same day as this.
-      * @param d2 the second `DateTime`
-      * @return `true` if the given `DateTime` is in the same day as this,
-      *         `false` othwerwise.
+      * @param d2
+      *   the second `DateTime`
+      * @return
+      *   `true` if the given `DateTime` is in the same day as this, `false` othwerwise.
       */
     def isSameDay(d2: DateTime) = d1.year == d2.year && d1.dayOfYear == d2.dayOfYear
 
-    /** Retuns `true` if this `DateTime` is in the range between the two given
-      * `DateTimes`.
-      * @param dStart the starting `DateTime`
-      * @param dEnd the ending `DateTime`
-      * @return `true` if this `DateTime` is in the range between the two given
-      *         `DateTimes`, `false` otherwise.
+    /** Retuns `true` if this `DateTime` is in the range between the two given `DateTimes`.
+      * @param dStart
+      *   the starting `DateTime`
+      * @param dEnd
+      *   the ending `DateTime`
+      * @return
+      *   `true` if this `DateTime` is in the range between the two given `DateTimes`, `false` otherwise.
       */
     def between(dStart: DateTime, dEnd: DateTime) = dStart < d1 && d1 < dEnd
 
-    /** Returns an iterable interval starting at this `DateTime` (inclusive) and
-      * ending at the given `DateTime` (exclusive), with a 1 day step.
-      * @param d2 the ending `DateTime`
-      * @return an iterable interval starting at this `DateTime` (inclusive) and
-      *         ending at the given `DateTime` (exclusive), with a 1 day step.
+    /** Returns an iterable interval starting at this `DateTime` (inclusive) and ending at the given `DateTime`
+      * (exclusive), with a 1 day step.
+      * @param d2
+      *   the ending `DateTime`
+      * @return
+      *   an iterable interval starting at this `DateTime` (inclusive) and ending at the given `DateTime` (exclusive),
+      *   with a 1 day step.
       */
     def until(d2: DateTime) = IterableInterval(d1 to d2, 1.day, false)
   }
 
   /** Implicit class that provides new methods for `ReadableIntervals`.
-    * @param interval the `ReadableInterval` to which the new methods are provided.
+    * @param interval
+    *   the `ReadableInterval` to which the new methods are provided.
     */
   final implicit class ApsoTimeInterval(val interval: ReadableInterval) extends AnyVal {
 
     /** Partitions this time interval into a given number of equal subintervals.
-      * @param n the number of subintervals to return
-      * @return a sequence of time intervals resultant of the division of this
-      *         interval in `n` equal parts.
+      * @param n
+      *   the number of subintervals to return
+      * @return
+      *   a sequence of time intervals resultant of the division of this interval in `n` equal parts.
       */
     def split(n: Int): Seq[ReadableInterval] = {
       require(n >= 0, "n must not be negative")
@@ -108,10 +123,12 @@ object Implicits {
     }
   }
 
-  /** Implicit method that allows whe view of a time interval as an indexed
-    * sequence. Time intervals are split with a 1 day step.
-    * @param interval the time interval to be iterated over
-    * @return an iterable time interval.
+  /** Implicit method that allows whe view of a time interval as an indexed sequence. Time intervals are split with a 1
+    * day step.
+    * @param interval
+    *   the time interval to be iterated over
+    * @return
+    *   an iterable time interval.
     */
   implicit def intervalToStepped(interval: ReadableInterval): IterableInterval = IterableInterval(interval, 1.day)
 }

--- a/time/src/main/scala/com/velocidi/apso/time/IterableInterval.scala
+++ b/time/src/main/scala/com/velocidi/apso/time/IterableInterval.scala
@@ -11,19 +11,20 @@ trait IterableInterval extends IndexedSeq[DateTime] {
     */
   val step: Period
 
-  /** Returns an iterable interval with the same time range and with the given
-    * step.
-    * @param step the step of the interval to return
-    * @return an iterable interval with the same time range and with the given
-    *         step.
+  /** Returns an iterable interval with the same time range and with the given step.
+    * @param step
+    *   the step of the interval to return
+    * @return
+    *   an iterable interval with the same time range and with the given step.
     */
   def by(step: Period): IterableInterval
 }
 
 /** A view of a `ReadableInterval` as an indexed sequence of `DateTimes`.
-  * @param interval the `ReadableInterval` to view as an indexed sequence
-  * @param step the period of time between consecutive `DateTimes` in the
-  *        sequence
+  * @param interval
+  *   the `ReadableInterval` to view as an indexed sequence
+  * @param step
+  *   the period of time between consecutive `DateTimes` in the sequence
   */
 case class SteppedInterval(interval: ReadableInterval, step: Period) extends IterableInterval {
 
@@ -44,8 +45,8 @@ case class SteppedInterval(interval: ReadableInterval, step: Period) extends Ite
 }
 
 /** An iterable time interval with no elements.
-  * @param step the period of time between consecutive `DateTimes`. Does not
-  *        affect an empty interval
+  * @param step
+  *   the period of time between consecutive `DateTimes`. Does not affect an empty interval
   */
 case class EmptySteppedInterval(step: Period) extends IterableInterval {
 
@@ -59,11 +60,14 @@ case class EmptySteppedInterval(step: Period) extends IterableInterval {
 object IterableInterval {
 
   /** Creates a new iterable time interval from a `ReadableInterval`.
-    * @param interval the `ReadableInterval` to view as an indexed sequence
-    * @param step the period of time between consecutive `DateTimes`
-    * @param lastInclusive `true` if the upper bound of the interval is to be
-    *        included in the sequence
-    * @return an iterable time interval with the given step.
+    * @param interval
+    *   the `ReadableInterval` to view as an indexed sequence
+    * @param step
+    *   the period of time between consecutive `DateTimes`
+    * @param lastInclusive
+    *   `true` if the upper bound of the interval is to be included in the sequence
+    * @return
+    *   an iterable time interval with the given step.
     */
   def apply(interval: ReadableInterval, step: Period, lastInclusive: Boolean = true): IterableInterval =
     if (lastInclusive) SteppedInterval(interval, step)


### PR DESCRIPTION
Updates `scalafmt` to 3.0.6 and applies the style changes. The dialect is required, otherwise, it prints warnings, so I chose `scala213` for Scala files and `sbt1` for SBT files.