### PR TITLE
Remove Log4j dependency from apso-log

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ JreVersionHelper.jreVersion
 
 ### Logging
 
-The `Logging` and `StrictLogging` traits allows mixing in Log4j2 `Logger` objects. The difference between the two is that in the former the `Logger` object is initialized lazily, while in the latter it is initialized strictly:
+The `Logging` and `StrictLogging` traits allows mixing in SLF4J `Logger` objects. The difference between the two is that in the former the `Logger` object is initialized lazily, while in the latter it is initialized strictly:
 
 ```scala
 import com.velocidi.apso.Logging

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -5,7 +5,6 @@ libraryDependencies ++= Seq(
   ApacheHttpClient,
   ApacheHttpCore,
   CirceCore,
-  Log4jCore         % Runtime,
   ScalaCollectionCompat,
   ScalaLogging,
   TypesafeConfig    % Provided,

--- a/docs/README.md
+++ b/docs/README.md
@@ -177,7 +177,7 @@ JreVersionHelper.jreVersion
 
 ### Logging
 
-The `Logging` and `StrictLogging` traits allows mixing in Log4j2 `Logger` objects. The difference between the two is that in the former the `Logger` object is initialized lazily, while in the latter it is initialized strictly:
+The `Logging` and `StrictLogging` traits allows mixing in SLF4J `Logger` objects. The difference between the two is that in the former the `Logger` object is initialized lazily, while in the latter it is initialized strictly:
 
 ```scala mdoc:compile-only
 import com.velocidi.apso.Logging

--- a/log/build.sbt
+++ b/log/build.sbt
@@ -1,3 +1,3 @@
 import Dependencies._
 
-libraryDependencies ++= Seq(Log4jCore % Runtime, ScalaLogging)
+libraryDependencies ++= Seq(ScalaLogging)

--- a/log/src/main/scala/com/velocidi/apso/Logging.scala
+++ b/log/src/main/scala/com/velocidi/apso/Logging.scala
@@ -2,7 +2,7 @@ package com.velocidi.apso
 
 import com.typesafe.scalalogging.Logger
 
-/** Trait to mixin a Log4j2 `Logger` object. The `Logger` object is initialized lazily.
+/** Trait to mixin an SLF4J `Logger` object. The `Logger` object is initialized lazily.
   */
 trait Logging {
 
@@ -11,7 +11,7 @@ trait Logging {
   lazy val log = Logger(getClass)
 }
 
-/** Trait to mixin a Log4j2 `Logger` object. The `Logger` object is initialized strictly.
+/** Trait to mixin an SLF4J `Logger` object. The `Logger` object is initialized strictly.
   */
 trait StrictLogging {
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,6 @@ object Dependencies {
     val FastMd5                 = "2.7.1"
     val JodaTime                = "2.10.13"
     val JUnit                   = "4.13.2"
-    val Log4jCore               = "2.14.1"
     val NscalaTime              = "2.30.0"
     val ScalaCheck              = "1.15.4"
     val ScalaLogging            = "3.9.4"
@@ -64,7 +63,6 @@ object Dependencies {
   val FastMd5                    = "com.joyent.util"             % "fast-md5"                     % Versions.FastMd5
   val JodaTime                   = "joda-time"                   % "joda-time"                    % Versions.JodaTime
   val JUnit                      = "junit"                       % "junit"                        % Versions.JUnit
-  val Log4jCore                  = "org.apache.logging.log4j"    % "log4j-core"                   % Versions.Log4jCore
   val NscalaTime                 = "com.github.nscala-time"     %% "nscala-time"                  % Versions.NscalaTime
   val ScalaCheck                 = "org.scalacheck"             %% "scalacheck"                   % Versions.ScalaCheck
   val ScalaCollectionCompat      = "org.scala-lang.modules"     %% "scala-collection-compat"      % "2.5.0"


### PR DESCRIPTION
Downstream dependencies can decide which logging backend to use.