### PR TITLE
Set up CI checks on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 env:
   CI: true # disables SBT super shell which has problems with CI environments


### PR DESCRIPTION
Enables CI checks on pull requests, otherwise branches not in this repository won't trigger builds, as seen by the recent Scala Steward PRs.