### PR TITLE
Define `esBasePath` as a `lazy val`

### DIFF
--- a/testkit/src/main/scala/com/velocidi/apso/elasticsearch/ElasticsearchTestKit.scala
+++ b/testkit/src/main/scala/com/velocidi/apso/elasticsearch/ElasticsearchTestKit.scala
@@ -29,7 +29,7 @@ trait ElasticsearchTestKit extends NoSpecElasticsearchTestKit with AfterAll {
 
 trait NoSpecElasticsearchTestKit {
   // This directory is deleted by the `.clean()` method from ElasticsearchClusterRunner.
-  val esBasePath = Files.createTempDirectory("es-cluster-runner").toAbsolutePath.toString
+  lazy val esBasePath = Files.createTempDirectory("es-cluster-runner").toAbsolutePath.toString
 
   val runner = new ElasticsearchClusterRunner().onBuild((_, settingsBuilder: Settings.Builder) => {
     settingsBuilder.put("http.cors.enabled", true)


### PR DESCRIPTION
Define `esBasePath` as a `lazy val` to avoid initialization problems with NPEs when extending traits.